### PR TITLE
test: add account-management DKVS AUTOPAY e2e

### DIFF
--- a/.github/workflows/account-management-dkvs-e2e.yml
+++ b/.github/workflows/account-management-dkvs-e2e.yml
@@ -49,6 +49,12 @@ jobs:
           ref: main
           path: satoshinet
 
+      - name: Checkout Transcend plugin
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/transcend
+          path: transcend
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/account-management-dkvs-e2e.yml
+++ b/.github/workflows/account-management-dkvs-e2e.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: sat20-labs/satoshinet
-          ref: main
+          ref: test/rpctest-skip-ossec-hardening
           path: satoshinet
 
       - name: Setup Go

--- a/.github/workflows/account-management-dkvs-e2e.yml
+++ b/.github/workflows/account-management-dkvs-e2e.yml
@@ -81,5 +81,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: account-management-dkvs-e2e-${{ github.run_id }}
-          path: /tmp/account-management-dkvs-e2e.log
+          path: |
+            /tmp/account-management-dkvs-e2e.log
+            /tmp/sat20wallet-satoshinet-rpctest-failures/**
+          if-no-files-found: warn
           retention-days: 3

--- a/.github/workflows/account-management-dkvs-e2e.yml
+++ b/.github/workflows/account-management-dkvs-e2e.yml
@@ -1,0 +1,73 @@
+name: Account management DKVS AUTOPAY e2e
+
+on:
+  push:
+    branches: [feat/account-management-dkvs-e2e]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sdk/e2e/account_management_dkvs_e2e_test.go'
+      - 'sdk/e2e/dkvs_e2e_test.go'
+      - 'sdk/wallet/dkvs_client.go'
+      - '.github/workflows/account-management-dkvs-e2e.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: account-management-dkvs-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout wallet
+        uses: actions/checkout@v4
+        with:
+          path: sat20wallet
+          fetch-depth: 0
+
+      - name: Checkout indexer
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/indexer
+          path: indexer
+
+      - name: Checkout RGB11 engine
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/rgb11
+          path: rgb11
+
+      - name: Checkout SatoshiNet
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/satoshinet
+          ref: main
+          path: satoshinet
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: sat20wallet/sdk/go.mod
+          cache: false
+
+      - name: Check Go formatting
+        working-directory: sat20wallet
+        shell: bash
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR origin/main...HEAD -- '*.go')
+          if [[ -n "$files" ]]; then
+            unformatted=$(gofmt -l $files)
+            if [[ -n "$unformatted" ]]; then
+              printf 'Unformatted files:\n%s\n' "$unformatted"
+              exit 1
+            fi
+          fi
+
+      - name: Run account-management DKVS AUTOPAY e2e
+        working-directory: sat20wallet/sdk
+        run: go test ./e2e -run '^TestRealSatoshiNetAccountManagementAutopaySync$' -count=1 -v

--- a/.github/workflows/account-management-dkvs-e2e.yml
+++ b/.github/workflows/account-management-dkvs-e2e.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - 'sdk/e2e/account_management_dkvs_e2e_test.go'
+      - 'sdk/e2e/dkvs_noplugin_harness_test.go'
       - 'sdk/e2e/dkvs_e2e_test.go'
       - 'sdk/wallet/dkvs_client.go'
       - '.github/workflows/account-management-dkvs-e2e.yml'
@@ -48,12 +49,6 @@ jobs:
           repository: sat20-labs/satoshinet
           ref: main
           path: satoshinet
-
-      - name: Checkout Transcend plugin
-        uses: actions/checkout@v4
-        with:
-          repository: sat20-labs/transcend
-          path: transcend
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/account-management-dkvs-e2e.yml
+++ b/.github/workflows/account-management-dkvs-e2e.yml
@@ -70,4 +70,15 @@ jobs:
 
       - name: Run account-management DKVS AUTOPAY e2e
         working-directory: sat20wallet/sdk
-        run: go test ./e2e -run '^TestRealSatoshiNetAccountManagementAutopaySync$' -count=1 -v
+        shell: bash
+        run: |
+          set -o pipefail
+          go test ./e2e -run '^TestRealSatoshiNetAccountManagementAutopaySync$' -count=1 -v 2>&1 | tee /tmp/account-management-dkvs-e2e.log
+
+      - name: Upload e2e diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: account-management-dkvs-e2e-${{ github.run_id }}
+          path: /tmp/account-management-dkvs-e2e.log
+          retention-days: 3

--- a/sdk/e2e/account_management_dkvs_e2e_test.go
+++ b/sdk/e2e/account_management_dkvs_e2e_test.go
@@ -1,0 +1,137 @@
+package e2e
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sat20-labs/sat20wallet/sdk/wallet"
+	"github.com/sat20-labs/satoshinet/chaincfg"
+	contractcommon "github.com/sat20-labs/satoshinet/contract"
+	templateruntime "github.com/sat20-labs/satoshinet/contract/template"
+	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+	"github.com/sat20-labs/satoshinet/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRealSatoshiNetAccountManagementAutopaySync verifies the network-facing
+// account-management storage contract on top of the real three-node DKVS e2e
+// fixture. Cryptographic account-envelope and Shamir reconstruction tests live
+// in wallet-sdk; this test proves that the package-versioned encrypted records
+// are owner-signed, paid through AUTOPAY, propagated, indexed and retrievable.
+func TestRealSatoshiNetAccountManagementAutopaySync(t *testing.T) {
+	defaults := dkvsindexer.NetworkDefaultsForParams(&chaincfg.TestNetParams)
+	f := newTemplateFixtureWithArgs(t,
+		map[string]int64{defaults.AutopayFeeAssetName: 20000}, nil, nil, dkvsMinerArgs(t))
+	waitForDKVSPeerReady(t, f.Network)
+
+	gas := contractcommon.GetGasAssetName()
+	owner := newDKVSKeyPathActor(t, keyFromMnemonic(t, dkvsClientMnemonic, 0))
+	require.Equal(t, defaults.AutopayDeployer, owner.Address)
+
+	gasOuts := splitToDKVSKeyPathActors(t, f, f.gasAnchor, gas,
+		[]int64{300000, 300000},
+		[]int64{10000, 10000},
+		[]*dkvsKeyPathActor{owner, owner})
+	feeOuts := splitToDKVSKeyPathActors(t, f, f.assetAnchors[defaults.AutopayFeeAssetName],
+		defaults.AutopayFeeAssetName,
+		[]int64{5000},
+		[]int64{10000},
+		[]*dkvsKeyPathActor{owner})
+
+	content, err := defaults.AutopayContent()
+	require.NoError(t, err)
+	deployAssets := txAsset(gas, 290000)
+	deployAssets = append(deployAssets, txAsset(defaults.AutopayFeeAssetName, 5000)...)
+	deploy, contractAddress := buildDKVSKeyPathTemplateDeploy(t, owner,
+		contractcommon.TemplateAutopay, content, owner.Address, defaults.AutopayDeployNonce,
+		[]dkvsPrevOut{gasOuts[0], feeOuts[0]},
+		wire.TxOut{Value: 10000, Assets: deployAssets})
+	f.Network.sendManyAndMine(t, []*wire.MsgTx{deploy}, 0)
+
+	heartbeat := buildDKVSKeyPathAssetTransfer(t, owner, gasOuts[1], gas, 290000, 9000, owner)
+	f.Network.sendManyAndMine(t, []*wire.MsgTx{heartbeat}, 0)
+	state := fetchTemplateAutopayView(t, f.Network.Bootstrap, contractAddress.MustEncode())
+	require.Equal(t, templateruntime.AutopayStatusActive, state.Status)
+	require.Contains(t, state.Delegates, owner.Address)
+
+	pubKey := owner.Wallet.GetPubKey().SerializeCompressed()
+	accountID := dkvsindexer.AccountID(pubKey)
+	packageID := strings.Repeat("a1", 16)
+	basePath := "account/recovery/" + packageID
+	prefix, err := dkvsindexer.PersonalKey(pubKey, basePath)
+	require.NoError(t, err)
+
+	minerClient := dkvsClientForNode(t, f.Network.Miner)
+	_, _, err = minerClient.SubscribePrefix(prefix)
+	require.NoError(t, err)
+	require.NoError(t, connectNode(f.Network.Miner, f.Network.Core))
+
+	type locator struct {
+		Version      int    `json:"version"`
+		AccountID    string `json:"account_id"`
+		PackageID    string `json:"package_id"`
+		RecoveryMode string `json:"recovery_mode"`
+	}
+	loc := locator{Version: 1, AccountID: accountID, PackageID: packageID, RecoveryMode: "2of3"}
+	envelope, err := json.Marshal(map[string]interface{}{
+		"version": 1,
+		"locator": loc,
+		"encrypted_backup": map[string]string{
+			"algorithm":  "aes-256-gcm",
+			"iv":         "fixture-iv",
+			"auth_tag":   "fixture-auth-tag",
+			"ciphertext": "fixture-encrypted-account-backup",
+		},
+	})
+	require.NoError(t, err)
+	manifest, err := json.Marshal(map[string]interface{}{
+		"version":       1,
+		"locator":       loc,
+		"threshold":     2,
+		"total":         3,
+		"envelope_hash": "fixture-envelope-hash",
+	})
+	require.NoError(t, err)
+
+	values := []struct {
+		path  string
+		value []byte
+	}{
+		{path: basePath + "/envelope", value: envelope},
+		{path: basePath + "/share/dkvs", value: []byte("fixture-encrypted-dkvs-share-capsule")},
+		{path: basePath + "/questions", value: []byte("fixture-encrypted-private-question-set")},
+		// Manifest is the application-level commit marker and is intentionally written last.
+		{path: basePath + "/manifest", value: manifest},
+	}
+
+	client := dkvsClientForNode(t, f.Network.Bootstrap)
+	autopay := wallet.DKVSAutopayOptions{
+		AddressParams: &chaincfg.TestNetParams,
+		PoolContract:  contractAddress.MustEncode(),
+	}
+	for _, item := range values {
+		_, err := client.PutPersonalRecordWithAutopay(owner.Wallet, item.path, item.value,
+			dkvsindexer.RecordOptions{Seq: 1, TTL: 60_000, ExpiryHeight: 1000}, autopay)
+		require.NoError(t, err)
+	}
+
+	for _, item := range values {
+		key, err := dkvsindexer.PersonalKey(pubKey, item.path)
+		require.NoError(t, err)
+		requireDKVSValue(t, f.Network.Bootstrap, key, item.value)
+		requireDKVSValue(t, f.Network.Core, key, item.value)
+		requireDKVSValue(t, f.Network.Miner, key, item.value)
+	}
+
+	records, total, err := dkvsClientForNode(t, f.Network.Core).ListRecords(prefix, 0, 10)
+	require.NoError(t, err)
+	require.Equal(t, len(values), total)
+	require.Len(t, records, len(values))
+
+	usage, err := dkvsClientForNode(t, f.Network.Core).GetUsage(prefix)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, uint64(len(values)), usage.ActiveRecords)
+	require.Greater(t, usage.ActiveBytes, uint64(0))
+}

--- a/sdk/e2e/account_management_dkvs_e2e_test.go
+++ b/sdk/e2e/account_management_dkvs_e2e_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 // TestRealSatoshiNetAccountManagementAutopaySync verifies the network-facing
-// account-management storage contract on top of the real three-node DKVS e2e
+// account-management storage contract on top of a real public three-node DKVS
 // fixture. Cryptographic account-envelope and Shamir reconstruction tests live
 // in wallet-sdk; this test proves that the package-versioned encrypted records
 // are owner-signed, paid through AUTOPAY, propagated, indexed and retrievable.
 func TestRealSatoshiNetAccountManagementAutopaySync(t *testing.T) {
 	defaults := dkvsindexer.NetworkDefaultsForParams(&chaincfg.TestNetParams)
-	f := newTemplateFixtureWithArgs(t,
+	f := newDKVSNoPluginTemplateFixtureWithArgs(t,
 		map[string]int64{defaults.AutopayFeeAssetName: 20000}, nil, nil, dkvsMinerArgs(t))
 	waitForDKVSPeerReady(t, f.Network)
 

--- a/sdk/e2e/account_management_dkvs_e2e_test.go
+++ b/sdk/e2e/account_management_dkvs_e2e_test.go
@@ -133,5 +133,5 @@ func TestRealSatoshiNetAccountManagementAutopaySync(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, uint64(len(values)), usage.ActiveRecords)
-	require.Greater(t, usage.ActiveBytes, uint64(0))
+	require.Greater(t, usage.ActiveTotalSize, uint64(0))
 }

--- a/sdk/e2e/dkvs_noplugin_harness_test.go
+++ b/sdk/e2e/dkvs_noplugin_harness_test.go
@@ -22,8 +22,8 @@ var (
 )
 
 // dkvsNoPluginBuildArtifacts builds public test binaries that do not depend on
-// the private Transcend STP plugin. DKVS and template AUTOPAY behavior are
-// provided by SatoshiNet itself; only the miner wallet plugin is required.
+// the private Transcend STP plugin. Every generating node still needs a wallet
+// signer, so bootstrap, core and miner all use the public sat20wallet plugin.
 func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	t.Helper()
 	dkvsNoPluginBuildMu.Lock()
@@ -43,14 +43,14 @@ func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	outputDir := filepath.Join(os.TempDir(), "sat20wallet-satoshinet-dkvs-rpctest")
 	require.NoError(t, os.MkdirAll(outputDir, 0o755))
 
-	artifacts := satoshinetArtifacts{
-		coreExecutable:  filepath.Join(outputDir, "satoshinet-core-dkvs-rpctest"),
-		minerExecutable: filepath.Join(outputDir, "satoshinet-miner-dkvs-rpctest"),
-		minerPlugin:     filepath.Join(outputDir, "wallet.so"),
-	}
+	nodeExecutable := filepath.Join(outputDir, "satoshinet-wallet-dkvs-rpctest")
 	if runtime.GOOS == "windows" {
-		artifacts.coreExecutable += ".exe"
-		artifacts.minerExecutable += ".exe"
+		nodeExecutable += ".exe"
+	}
+	artifacts := satoshinetArtifacts{
+		coreExecutable:  nodeExecutable,
+		minerExecutable: nodeExecutable,
+		minerPlugin:     filepath.Join(outputDir, "wallet.so"),
 	}
 
 	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", artifacts.minerPlugin, "main.go")
@@ -58,13 +58,7 @@ func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	cmd = exec.Command("go", "build", "-tags=rpctest,wallet_plugin", "-o", artifacts.minerExecutable,
-		"github.com/sat20-labs/satoshinet")
-	cmd.Dir = satoshinetDir
-	output, err = cmd.CombinedOutput()
-	require.NoError(t, err, string(output))
-
-	cmd = exec.Command("go", "build", "-tags=rpctest", "-o", artifacts.coreExecutable,
+	cmd = exec.Command("go", "build", "-tags=rpctest,wallet_plugin", "-o", nodeExecutable,
 		"github.com/sat20-labs/satoshinet")
 	cmd.Dir = satoshinetDir
 	output, err = cmd.CombinedOutput()
@@ -81,9 +75,11 @@ func stageDKVSNoPluginNodeRuntime(t *testing.T, role, mnemonic, l1IndexerHost, l
 	executable := artifacts.coreExecutable
 	if role == "miner" {
 		executable = artifacts.minerExecutable
-		copySatoshiNetRuntimeFile(t, artifacts.minerPlugin, filepath.Join(nodeDir, "wallet.so"))
 	}
 
+	// Generating bootstrap/core nodes and the miner all require the public wallet
+	// plugin for STP signing. This keeps the fixture independent of Transcend.
+	copySatoshiNetRuntimeFile(t, artifacts.minerPlugin, filepath.Join(nodeDir, "wallet.so"))
 	stagedExecutable := filepath.Join(nodeDir, filepath.Base(executable))
 	copySatoshiNetRuntimeFile(t, executable, stagedExecutable)
 	require.NoError(t, os.WriteFile(filepath.Join(nodeDir, "conf.yaml"), []byte(fmt.Sprintf(satoshinetTestConf,

--- a/sdk/e2e/dkvs_noplugin_harness_test.go
+++ b/sdk/e2e/dkvs_noplugin_harness_test.go
@@ -1,0 +1,228 @@
+package e2e
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	indexercommon "github.com/sat20-labs/indexer/common"
+	contractcommon "github.com/sat20-labs/satoshinet/contract"
+	"github.com/sat20-labs/satoshinet/wire"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dkvsNoPluginBuildMu       sync.Mutex
+	dkvsNoPluginTestArtifacts satoshinetArtifacts
+)
+
+// dkvsNoPluginBuildArtifacts builds public test binaries that do not depend on
+// the private Transcend STP plugin. DKVS and template AUTOPAY behavior are
+// provided by SatoshiNet itself; only the miner wallet plugin is required.
+func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
+	t.Helper()
+	dkvsNoPluginBuildMu.Lock()
+	defer dkvsNoPluginBuildMu.Unlock()
+	if dkvsNoPluginTestArtifacts.coreExecutable != "" {
+		return dkvsNoPluginTestArtifacts
+	}
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	workspace := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	satoshinetDir := filepath.Join(workspace, "satoshinet")
+	require.FileExists(t, filepath.Join(satoshinetDir, "go.mod"))
+	sdkPluginDir := filepath.Join(workspace, "sat20wallet", "sdk", "plugin")
+	require.FileExists(t, filepath.Join(sdkPluginDir, "main.go"))
+
+	outputDir := filepath.Join(os.TempDir(), "sat20wallet-satoshinet-dkvs-rpctest")
+	require.NoError(t, os.MkdirAll(outputDir, 0o755))
+
+	artifacts := satoshinetArtifacts{
+		coreExecutable:  filepath.Join(outputDir, "satoshinet-core-dkvs-rpctest"),
+		minerExecutable: filepath.Join(outputDir, "satoshinet-miner-dkvs-rpctest"),
+		minerPlugin:     filepath.Join(outputDir, "wallet.so"),
+	}
+	if runtime.GOOS == "windows" {
+		artifacts.coreExecutable += ".exe"
+		artifacts.minerExecutable += ".exe"
+	}
+
+	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", artifacts.minerPlugin, "main.go")
+	cmd.Dir = sdkPluginDir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	cmd = exec.Command("go", "build", "-tags=rpctest,wallet_plugin", "-o", artifacts.minerExecutable,
+		"github.com/sat20-labs/satoshinet")
+	cmd.Dir = satoshinetDir
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	cmd = exec.Command("go", "build", "-tags=rpctest", "-o", artifacts.coreExecutable,
+		"github.com/sat20-labs/satoshinet")
+	cmd.Dir = satoshinetDir
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	dkvsNoPluginTestArtifacts = artifacts
+	return dkvsNoPluginTestArtifacts
+}
+
+func stageDKVSNoPluginNodeRuntime(t *testing.T, role, mnemonic, l1IndexerHost, l2IndexerHost, rpcHost,
+	managementHost, nodeDir string) string {
+	t.Helper()
+	artifacts := dkvsNoPluginBuildArtifacts(t)
+	executable := artifacts.coreExecutable
+	if role == "miner" {
+		executable = artifacts.minerExecutable
+		copySatoshiNetRuntimeFile(t, artifacts.minerPlugin, filepath.Join(nodeDir, "wallet.so"))
+	}
+
+	stagedExecutable := filepath.Join(nodeDir, filepath.Base(executable))
+	copySatoshiNetRuntimeFile(t, executable, stagedExecutable)
+	require.NoError(t, os.WriteFile(filepath.Join(nodeDir, "conf.yaml"), []byte(fmt.Sprintf(satoshinetTestConf,
+		l1IndexerHost, l2IndexerHost, rpcHost, managementHost, mnemonic)), 0o600))
+	return stagedExecutable
+}
+
+func startDKVSNoPluginNodeWithArgs(t *testing.T, fakeL1 *fakeL1Indexer, role, mnemonic string,
+	extraArgs []string) *testHarness {
+	t.Helper()
+
+	nodeKey := keyFromMnemonic(t, mnemonic, 0)
+	nodePubKey := hex.EncodeToString(nodeKey.PubKey().SerializeCompressed())
+	p2pAddr, rpcAddr, managementAddr := nextNodeAddresses(t)
+	nodeDir := t.TempDir()
+	dataDir := filepath.Join(nodeDir, "data")
+	logDir := filepath.Join(nodeDir, "logs")
+	args := []string{
+		"--notls",
+		"--nocheckpoints",
+		"--nodnsseed",
+		"--testnet",
+		"--listen=" + p2pAddr,
+		"--rpclisten=" + rpcAddr,
+		"--rpcuser=user",
+		"--rpcpass=pass",
+		"--datadir=" + dataDir,
+		"--logdir=" + logDir,
+		"--indexerscheme=http",
+		"--indexerhost=" + fakeL1.host(),
+		"--indexerproxy=testnet",
+	}
+	if role != "miner" {
+		args = append(args, "--generate", "--miningpubkey="+nodePubKey)
+	}
+	args = append(args, extraArgs...)
+	env := []string{
+		"SATOSHINET_RPCTEST_NODE_ROLE=" + role,
+		"SATOSHINET_RPCTEST_STP_MNEMONIC=" + mnemonic,
+		"SATOSHINET_RPCTEST_STP_PASSWORD=rpctest",
+	}
+	for _, name := range []string{
+		"SATOSHINET_POS_MINER_INTERVAL",
+		"SATOSHINET_POS_PREWARNING_INTERVAL",
+		"SATOSHINET_POS_CHECKING_INTERVAL",
+	} {
+		if value := os.Getenv(name); value != "" {
+			env = append(env, name+"="+value)
+		}
+	}
+
+	harness := newTestHarness(t, stageDKVSNoPluginNodeRuntime(t, role, mnemonic, fakeL1.host(),
+		l2IndexerHost(t, rpcAddr), rpcAddr, managementAddr, nodeDir), nodeDir, p2pAddr, rpcAddr, args, env)
+	t.Logf("started public DKVS %s node: pid=%d rpc=%s p2p=%s log=%s", role, harness.NodePID(),
+		harness.RPCAddress(), harness.P2PAddress(), harness.LogFile())
+	return harness
+}
+
+func newDKVSNoPluginNetworkWithArgs(t *testing.T, fakeL1 *fakeL1Indexer, bootstrapArgs, coreArgs,
+	minerArgs []string) *realSatoshiNet {
+	t.Helper()
+	configureFastPOSTimers(t)
+
+	bootstrap := startDKVSNoPluginNodeWithArgs(t, fakeL1, "bootstrap", bootstrapMnemonic, bootstrapArgs)
+	core := startDKVSNoPluginNodeWithArgs(t, fakeL1, "core", coreMnemonic, coreArgs)
+	miner := startDKVSNoPluginNodeWithArgs(t, fakeL1, "miner", minerMnemonic, minerArgs)
+
+	require.NoError(t, connectNode(core, bootstrap))
+	require.NoError(t, connectNode(miner, bootstrap))
+	nodes := []*testHarness{bootstrap, core, miner}
+	require.NoError(t, joinBlocks(nodes))
+	return &realSatoshiNet{Bootstrap: bootstrap, Core: core, Miner: miner, Nodes: nodes, fakeL1: fakeL1}
+}
+
+func newDKVSNoPluginTemplateFixtureWithArgs(t *testing.T, assets map[string]int64, bootstrapArgs,
+	coreArgs, minerArgs []string) *templateFixture {
+	t.Helper()
+	profiles := make([]templateAssetProfile, 0, len(assets))
+	for _, asset := range sortedAssetNames(assets) {
+		profiles = append(profiles, templateAssetProfile{Name: asset, Asset: asset, Precision: 0,
+			Supply: fmt.Sprintf("%d", assets[asset])})
+	}
+	return newDKVSNoPluginTemplateFixtureWithProfilesAndArgs(t, profiles, bootstrapArgs, coreArgs, minerArgs)
+}
+
+func newDKVSNoPluginTemplateFixtureWithProfilesAndArgs(t *testing.T, profiles []templateAssetProfile,
+	bootstrapArgs, coreArgs, minerArgs []string) *templateFixture {
+	t.Helper()
+	oldEnableTesting := indexercommon.ENABLE_TESTING
+	indexercommon.ENABLE_TESTING = true
+	t.Cleanup(func() { indexercommon.ENABLE_TESTING = oldEnableTesting })
+
+	const lockedValue = int64(20_000_000)
+	gas := contractcommon.GetGasAssetName()
+	bootstrapKey := keyFromMnemonic(t, bootstrapMnemonic, 0)
+	coreKey := keyFromMnemonic(t, coreMnemonic, 0)
+	actorA := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 1))
+	actorB := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 2))
+	actorC := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 3))
+	actorD := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 4))
+	actorE := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 5))
+	actorF := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 6))
+
+	witnessScript, lockedPkScript, err := getP2WSHScript(bootstrapKey.PubKey().SerializeCompressed(),
+		coreKey.PubKey().SerializeCompressed())
+	require.NoError(t, err)
+
+	l1Assets := []fakeL1Asset{{
+		Utxo: templateLockedOutPoint("gas", 0), Value: lockedValue,
+		Assets: map[string]string{gas: "100000000"},
+	}}
+	profileMap := make(map[string]templateAssetProfile, len(profiles))
+	for i, profile := range sortedProfiles(profiles) {
+		profileMap[profile.Asset] = profile
+		l1Assets = append(l1Assets, fakeL1Asset{
+			Utxo: templateLockedOutPoint(profile.Asset, i+1), Value: lockedValue,
+			Assets: map[string]string{profile.Asset: profile.Supply},
+			Metadata: map[string]fakeL1AssetMeta{profile.Asset: {
+				Precision: profile.Precision, BindingSat: profile.BindingSat,
+			}},
+		})
+	}
+	fakeL1 := newFakeL1Indexer(t, hex.EncodeToString(bootstrapKey.PubKey().SerializeCompressed()),
+		lockedPkScript, l1Assets)
+	network := newDKVSNoPluginNetworkWithArgs(t, fakeL1, bootstrapArgs, coreArgs, minerArgs)
+
+	gasAnchor := buildAnchorTx(t, templateLockedOutPoint("gas", 0), lockedValue,
+		txAsset(gas, 100000000), gas+"-100000000-0-0", witnessScript, bootstrapKey, actorA.PkScript)
+	network.sendAndMine(t, gasAnchor, 1)
+
+	assetAnchors := make(map[string]*wire.MsgTx)
+	for i, profile := range sortedProfiles(profiles) {
+		anchor := buildAnchorTx(t, templateLockedOutPoint(profile.Asset, i+1), lockedValue,
+			txAssetProfile(t, profile, profile.Supply), fmt.Sprintf("%s-%s-%d-%d", profile.Asset,
+				profile.Supply, profile.Precision, profile.BindingSat), witnessScript, bootstrapKey, actorA.PkScript)
+		network.sendAndMine(t, anchor, 1)
+		assetAnchors[profile.Asset] = anchor
+	}
+
+	return &templateFixture{Network: network, A: actorA, B: actorB, C: actorC, D: actorD, E: actorE,
+		F: actorF, gasAnchor: gasAnchor, assetAnchors: assetAnchors, profiles: profileMap}
+}


### PR DESCRIPTION
Superseded by `sat20-labs/sat20wallet#5`.

The three-node DKVS AUTOPAY test has been moved into the consolidated account-management PR and expanded to create a real Go account recovery package, store the Guardian capsule, read from another node, and complete full account recovery. This standalone test PR is intentionally closed without merge.