### PR TITLE
feat: add DKVS-backed self-custodial account management

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -1,0 +1,144 @@
+name: Account management
+
+on:
+  push:
+    branches: [feat/account-management-complete]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sdk/account/**'
+      - 'sdk/wallet/account_*.go'
+      - 'sdk/e2e/account_management_dkvs_e2e_test.go'
+      - 'sdk/e2e/dkvs_noplugin_harness_test.go'
+      - 'sdk/e2e/testdata/satoshinet-rpctest-hardening.patch'
+      - 'pwa/lib/secure-account-storage.ts'
+      - 'docs/account-management.md'
+      - 'docs/account-secure-storage.md'
+      - '.github/workflows/account-management.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: account-management-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-account:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout wallet
+        uses: actions/checkout@v4
+        with:
+          path: sat20wallet
+          fetch-depth: 0
+      - name: Checkout indexer
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/indexer
+          path: indexer
+      - name: Checkout RGB11 engine
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/rgb11
+          path: rgb11
+      - name: Checkout SatoshiNet
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/satoshinet
+          path: satoshinet
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: sat20wallet/sdk/go.mod
+          cache: false
+      - name: Check Go formatting
+        working-directory: sat20wallet
+        shell: bash
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR origin/main...HEAD -- \
+            'sdk/account/**/*.go' 'sdk/account/*.go' 'sdk/wallet/account_*.go' \
+            'sdk/e2e/account_management_dkvs_e2e_test.go' 'sdk/e2e/dkvs_noplugin_harness_test.go')
+          if [[ -n "$files" ]]; then
+            unformatted=$(gofmt -l $files)
+            if [[ -n "$unformatted" ]]; then
+              printf 'Unformatted files:\n%s\n' "$unformatted"
+              exit 1
+            fi
+          fi
+      - name: Test account packages
+        working-directory: sat20wallet/sdk
+        run: go test ./account/... -count=1
+      - name: Compile wallet integration
+        working-directory: sat20wallet/sdk
+        run: go test ./wallet -run '^$' -count=1
+
+  pwa-secure-storage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: pwa/package-lock.json
+      - name: Install PWA dependencies
+        working-directory: pwa
+        run: npm install --ignore-scripts --no-audit --no-fund
+      - name: Type-check PWA
+        working-directory: pwa
+        run: npm run compile
+
+  dkvs-autopay-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout wallet
+        uses: actions/checkout@v4
+        with:
+          path: sat20wallet
+          fetch-depth: 0
+      - name: Checkout indexer
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/indexer
+          path: indexer
+      - name: Checkout RGB11 engine
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/rgb11
+          path: rgb11
+      - name: Checkout SatoshiNet
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/satoshinet
+          path: satoshinet
+      - name: Apply rpctest-only SatoshiNet hardening patch
+        shell: bash
+        run: git -C satoshinet apply ../sat20wallet/sdk/e2e/testdata/satoshinet-rpctest-hardening.patch
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: sat20wallet/sdk/go.mod
+          cache: false
+      - name: Run account-management DKVS AUTOPAY e2e
+        working-directory: sat20wallet/sdk
+        shell: bash
+        run: |
+          set -o pipefail
+          go test ./e2e -run '^TestRealSatoshiNetAccountManagementAutopaySync$' -count=1 -v 2>&1 | tee /tmp/account-management-dkvs-e2e.log
+      - name: Upload e2e diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: account-management-dkvs-e2e-${{ github.run_id }}
+          path: |
+            /tmp/account-management-dkvs-e2e.log
+            /tmp/sat20wallet-satoshinet-rpctest-failures/**
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -18,39 +18,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: account-management-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  format:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
-          fetch-depth: 0
-      - name: Format Go files
-        shell: bash
-        run: |
-          files=$(git diff --name-only --diff-filter=ACMR origin/main...HEAD -- \
-            'sdk/account/**/*.go' 'sdk/account/*.go' 'sdk/wallet/account_*.go' \
-            'sdk/e2e/account_management_dkvs_e2e_test.go' 'sdk/e2e/dkvs_noplugin_harness_test.go')
-          if [[ -n "$files" ]]; then
-            gofmt -w $files
-          fi
-          if ! git diff --quiet; then
-            git config user.name github-actions[bot]
-            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-            git add $files
-            git commit -m 'style(account): gofmt consolidated account code'
-            git push origin HEAD:${{ github.ref_name }}
-          fi
-
   go-account:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -18,13 +18,39 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: account-management-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  format:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+      - name: Format Go files
+        shell: bash
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR origin/main...HEAD -- \
+            'sdk/account/**/*.go' 'sdk/account/*.go' 'sdk/wallet/account_*.go' \
+            'sdk/e2e/account_management_dkvs_e2e_test.go' 'sdk/e2e/dkvs_noplugin_harness_test.go')
+          if [[ -n "$files" ]]; then
+            gofmt -w $files
+          fi
+          if ! git diff --quiet; then
+            git config user.name github-actions[bot]
+            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+            git add $files
+            git commit -m 'style(account): gofmt consolidated account code'
+            git push origin HEAD:${{ github.ref_name }}
+          fi
+
   go-account:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -89,7 +89,7 @@ jobs:
           cache-dependency-path: pwa/package-lock.json
       - name: Install PWA dependencies
         working-directory: pwa
-        run: npm install --ignore-scripts --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Type-check PWA
         working-directory: pwa
         run: npm run compile

--- a/docs/account-management.md
+++ b/docs/account-management.md
@@ -1,0 +1,171 @@
+# Wallet SDK 自托管账户管理系统
+
+版本：v1 开发设计  
+实现位置：`sat20wallet/sdk/account`、`sat20wallet/sdk/wallet`
+
+## 1. 目标
+
+账户管理系统以 DKVS 为公开密文存储层，在 Go Wallet SDK 中完成账户备份、加密、恢复和新设备恢复演练。
+
+账户备份只包含：
+
+```text
+多个钱包助记词
+钱包名称
+每个钱包的子账户数量
+子账户派生 index
+子账户 Ordinals DID 名称
+```
+
+链上合约、余额、资产、交易历史从 indexer 重新获取；应用设置由应用管理。
+
+## 2. 自托管边界
+
+```text
+DKVS 只保存密文和公开恢复 helper data
+账户 owner 签名并通过同一钱包 AUTOPAY
+单个 Shamir 分片不能恢复账户
+单个私人知识问题不能恢复 DKVS 分片
+Guardian 单独不能恢复账户
+恢复与解密全部在用户设备本地完成
+```
+
+## 3. AccountSecret 与账户密文
+
+创建恢复包时生成随机 32-byte `AccountSecret`。账户备份使用 AES-256-GCM 加密；密钥通过 HKDF-SHA256 从 `AccountSecret`、account ID 和 recovery package ID 派生。AAD 绑定：
+
+```text
+version
+account_id
+package_id
+recovery_mode
+```
+
+## 4. Shamir 恢复模式
+
+Go SDK 使用 GF(2^8) Shamir，系数来自 `crypto/rand`，公开 share index 固定为 1..N。分片外层包含 package ID、阈值、总数、角色和 checksum。
+
+### 2/3 便利恢复
+
+```text
+S_user
+S_dkvs
+S_guardian
+任意两片恢复 AccountSecret
+```
+
+普通用户可以通过私人知识恢复 `S_dkvs`，再由 Guardian 提供 `S_guardian`，无需依赖长期保存纸质分片。
+
+### 2/2 增强安全
+
+```text
+S_user + S_dkvs
+```
+
+用户自己持有的分片是密码学上的必要条件。
+
+## 5. 私人知识 Fuzzy Recovery
+
+不使用旧版 `float64 + SimHash + chaff` PoC。实现参考 Decentralized Identity Foundation `fuzzy-encryption`，移植为纯 Go：
+
+```text
+有限素数域
+多项式 secure sketch
+Berlekamp–Welch 错误恢复
+scrypt 集合校验
+HMAC-SHA3-512 确定性密钥派生
+CSPRNG
+```
+
+每个问题独立保护 `K_dkvs` 的一个 2/3 Shamir 分片：
+
+```text
+问题 1 -> QShare1
+问题 2 -> QShare2
+问题 3 -> QShare3
+任意两个正确问题 -> K_dkvs -> 解密 S_dkvs
+```
+
+问题应当答案明确、长期可记忆、但外部难枚举。例如书籍问题必须指定书名、作者、语言、版本/ISBN、页码和取值规则。
+
+答案本地执行 Unicode NFKC、空白规范化和问题级标点/大小写规则。中文与自然语言通过 rune unigram/bigram/trigram 提取固定数量的 package-bound feature ID。
+
+## 6. Guardian
+
+Guardian 使用独立 X25519 recovery key，不复用钱包资产私钥。`S_guardian` 通过 X25519 ECDH + AES-256-GCM 加密，保存在 Guardian mailbox share 路径：
+
+```text
+/mail/<guardian_mailbox_id>/share/<package_id>/<share_id>
+```
+
+Guardian 钱包读取、解密后只把分片重新加密给恢复设备，不显示明文分片。
+
+## 7. DKVS 数据布局
+
+```text
+/personal/<account_id>/account/recovery/<package_id>/envelope
+/personal/<account_id>/account/recovery/<package_id>/share/dkvs
+/personal/<account_id>/account/recovery/<package_id>/questions
+/personal/<account_id>/account/recovery/<package_id>/manifest
+```
+
+写入顺序固定为：
+
+```text
+envelope
+share/dkvs
+questions
+manifest
+```
+
+Manifest 最后写入，作为应用层 commit marker。账户 record 使用 account owner 签名并由同一 wallet 的 AUTOPAY 支付。
+
+## 8. 新设备
+
+添加新设备必须完成一次真实恢复演练：
+
+```text
+1. 从 DKVS 获取恢复包
+2. 获得满足阈值的分片
+3. Go SDK 恢复 AccountSecret
+4. 解密账户备份
+5. 只展示钱包名、子账户数量和 DID 名称
+6. 用户确认
+7. PWA/native SecureAccountStorage.seal
+8. 清除临时秘密
+```
+
+不通过旧设备直接展示或复制助记词。
+
+## 9. Go 包结构
+
+```text
+sdk/account
+  账户模型、AES-GCM、Shamir、Fuzzy Recovery、Guardian、恢复流程
+
+sdk/account/fuzzy
+  DIF fuzzy-encryption 的纯 Go 移植
+
+sdk/wallet/account_repository.go
+  DKVS `/personal` repository、owner 签名、AUTOPAY
+
+sdk/wallet/account_guardian.go
+  Guardian mailbox share AUTOPAY 写入
+```
+
+PWA 层只负责 UI、平台安全存储和 Go/WASM 调用。
+
+## 10. E2E
+
+真实三节点测试验证：
+
+```text
+AUTOPAY 部署和激活
+账户 recovery package 创建
+owner-signed /personal record
+bootstrap/core/miner P2P 同步
+manifest-last 写入
+prefix list 与 usage
+Guardian mailbox share
+从 core 节点读取后完整恢复账户
+```

--- a/docs/account-secure-storage.md
+++ b/docs/account-secure-storage.md
@@ -1,0 +1,68 @@
+# 账户安全设备存储设计
+
+版本：v0.2  
+适用项目：sat20wallet PWA / Capacitor App  
+上层依赖：Go `sdk/account` 通过 WASM 或原生绑定完成恢复
+
+## 1. 边界
+
+Go SDK 完成账户加密、Shamir 恢复、Fuzzy Recovery 和 DKVS 读取。恢复后的 `AccountSecret` 如何保存在当前设备，由 PWA / 原生应用层负责。
+
+```text
+助记词不明文持久化
+AccountSecret 不明文持久化
+生物识别只控制系统密钥的使用
+IndexedDB 只保存密文和 key-slot metadata
+添加设备必须完成一次真实账户恢复演练
+```
+
+## 2. 密钥层次
+
+每台设备生成独立随机 `DeviceWrappingKey`：
+
+```text
+WrappedAccountSecret = AEAD_Encrypt(
+  DeviceWrappingKey,
+  AccountSecret,
+  AAD = account_id || device_id || version
+)
+```
+
+IndexedDB 只保存 `WrappedAccountSecret`、credential ID、KDF 参数、设备 ID 和非秘密 metadata。
+
+## 3. 平台实现
+
+### Android
+
+使用 Capacitor 原生插件、Android Keystore、AES-256-GCM、`BiometricPrompt` 和设备凭据。可用时优先 hardware-backed / StrongBox。JavaScript 只调用 `seal` / `unseal`，不读取 Keystore key。
+
+### iOS
+
+使用 Keychain、`kSecAttrAccessibleWhenUnlockedThisDeviceOnly` 和 `SecAccessControl` 的 `userPresence`；可选 `biometryCurrentSet` 和 Secure Enclave ECDH 包装。JavaScript 不读取原生密钥。
+
+### macOS / Windows PWA
+
+首选 WebAuthn PRF：PRF 输出经 HKDF 派生 `DeviceWrappingKey`。运行时必须 feature-detect。
+
+PRF 不可用时，使用设备 PIN/长密码经 Argon2id 派生 KEK，KEK 只包装随机 `DeviceWrappingKey`。忘记 PIN 后执行完整账户恢复，不提供服务器重置。
+
+## 4. 统一接口
+
+见 `pwa/lib/secure-account-storage.ts`。Go/WASM 恢复成功、用户确认钱包名/子账户数/DID 后，PWA 调用 `seal`。
+
+## 5. 新设备流程
+
+```text
+1. 定位 DKVS recovery package
+2. 通过私人知识问题、Guardian 或用户分片得到满足阈值的分片
+3. Go SDK 本地恢复 AccountSecret
+4. 解密并展示钱包名、子账户数和 Ordinals DID
+5. 用户确认
+6. 创建当前设备 DeviceWrappingKey
+7. SecureAccountStorage.seal
+8. 清理恢复过程中的临时秘密
+```
+
+## 6. 迁移
+
+旧钱包数据迁移必须先创建 DKVS recovery package、完成一次恢复演练、验证新 key slot 可 `unseal`，之后再删除旧 IndexedDB/localStorage 中的敏感值。失败时保留旧数据并回滚。

--- a/pwa/lib/secure-account-storage.ts
+++ b/pwa/lib/secure-account-storage.ts
@@ -1,0 +1,48 @@
+export type SecureStorageMode = 'native-keystore' | 'webauthn-prf' | 'pin-wrapped'
+
+export interface SecureStorageCapabilities {
+  mode: SecureStorageMode
+  userPresence: boolean
+  hardwareBacked: boolean
+  biometricAvailable: boolean
+  recoverableByAccountRecovery: true
+}
+
+export interface DeviceKeySlotMetadata {
+  [key: string]: string | number | boolean
+}
+
+export interface DeviceKeySlot {
+  version: 1
+  accountId: string
+  deviceId: string
+  mode: SecureStorageMode
+  wrappedAccountSecret: string
+  metadata: DeviceKeySlotMetadata
+}
+
+export interface SealAccountSecretOptions { requireUserPresence?: boolean }
+export interface UnsealAccountSecretOptions { requireUserPresence?: boolean; reason?: string }
+
+/**
+ * Platform boundary invoked by the Go/WASM account recovery flow.
+ * IndexedDB may persist DeviceKeySlot but never the raw AccountSecret or
+ * DeviceWrappingKey.
+ */
+export interface SecureAccountStorage {
+  capabilities(): Promise<SecureStorageCapabilities>
+  seal(accountId: string, accountSecret: Uint8Array, options?: SealAccountSecretOptions): Promise<DeviceKeySlot>
+  unseal(accountId: string, options?: UnsealAccountSecretOptions): Promise<Uint8Array>
+  remove(accountId: string): Promise<void>
+}
+
+export class SecureAccountStorageUnavailableError extends Error {
+  constructor(message = 'Secure account storage is unavailable on this device') {
+    super(message)
+    this.name = 'SecureAccountStorageUnavailableError'
+  }
+}
+
+export const assertSecureStorageAccountId = (accountId: string): void => {
+  if (!/^[0-9a-f]{64}$/.test(accountId)) throw new Error('accountId must be a lowercase SHA-256 hex string')
+}

--- a/sdk/account/crypto.go
+++ b/sdk/account/crypto.go
@@ -1,0 +1,126 @@
+package account
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+func zero(value []byte) {
+	for i := range value {
+		value[i] = 0
+	}
+}
+
+func hkdfSHA256(secret, salt, info []byte, size int) []byte {
+	extract := hmac.New(sha256.New, salt)
+	_, _ = extract.Write(secret)
+	prk := extract.Sum(nil)
+	defer zero(prk)
+	out := make([]byte, 0, size)
+	var previous []byte
+	for counter := byte(1); len(out) < size; counter++ {
+		mac := hmac.New(sha256.New, prk)
+		_, _ = mac.Write(previous)
+		_, _ = mac.Write(info)
+		_, _ = mac.Write([]byte{counter})
+		previous = mac.Sum(nil)
+		out = append(out, previous...)
+	}
+	zero(previous)
+	return out[:size]
+}
+
+func locatorAAD(locator Locator, domain string) []byte {
+	return []byte(fmt.Sprintf("%s|%d|%s|%s|%s", domain, locator.Version, locator.AccountID, locator.PackageID, locator.RecoveryMode))
+}
+
+func deriveBackupKey(secret []byte, locator Locator) []byte {
+	return hkdfSHA256(secret, []byte(locator.PackageID), []byte("sat20-account-backup-v1|"+locator.AccountID), 32)
+}
+
+func sealBytes(key, plaintext, aad []byte, random io.Reader) (nonce, ciphertext string, err error) {
+	if len(key) != 32 {
+		return "", "", ErrInvalidRecoveryPackage
+	}
+	if random == nil {
+		random = rand.Reader
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", "", err
+	}
+	nonceBytes := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(random, nonceBytes); err != nil {
+		return "", "", err
+	}
+	sealed := gcm.Seal(nil, nonceBytes, plaintext, aad)
+	return base64.RawURLEncoding.EncodeToString(nonceBytes), base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func openSealed(key []byte, nonceText, ciphertextText string, aad []byte) ([]byte, error) {
+	nonce, err := base64.RawURLEncoding.DecodeString(nonceText)
+	if err != nil {
+		return nil, ErrRecoveryFailed
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(ciphertextText)
+	if err != nil {
+		return nil, ErrRecoveryFailed
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, ErrRecoveryFailed
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil || len(nonce) != gcm.NonceSize() {
+		return nil, ErrRecoveryFailed
+	}
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, ErrRecoveryFailed
+	}
+	return plaintext, nil
+}
+
+func encryptBackup(secret []byte, locator Locator, backup Backup, random io.Reader) (EncryptedBlob, error) {
+	plaintext, err := json.Marshal(backup)
+	if err != nil {
+		return EncryptedBlob{}, err
+	}
+	defer zero(plaintext)
+	key := deriveBackupKey(secret, locator)
+	defer zero(key)
+	nonce, ciphertext, err := sealBytes(key, plaintext, locatorAAD(locator, "sat20-account-backup-aad-v1"), random)
+	if err != nil {
+		return EncryptedBlob{}, err
+	}
+	return EncryptedBlob{Algorithm: "aes-256-gcm", Nonce: nonce, Ciphertext: ciphertext}, nil
+}
+
+func decryptBackup(secret []byte, locator Locator, encrypted EncryptedBlob) (Backup, error) {
+	if err := validateEncryptedBlob(encrypted); err != nil {
+		return Backup{}, err
+	}
+	key := deriveBackupKey(secret, locator)
+	defer zero(key)
+	plaintext, err := openSealed(key, encrypted.Nonce, encrypted.Ciphertext, locatorAAD(locator, "sat20-account-backup-aad-v1"))
+	if err != nil {
+		return Backup{}, err
+	}
+	defer zero(plaintext)
+	var backup Backup
+	if err := json.Unmarshal(plaintext, &backup); err != nil {
+		return Backup{}, ErrRecoveryFailed
+	}
+	return NormalizeBackup(backup)
+}

--- a/sdk/account/fuzzy/LICENSE
+++ b/sdk/account/fuzzy/LICENSE
@@ -1,0 +1,6 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this package except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.

--- a/sdk/account/fuzzy/NOTICE
+++ b/sdk/account/fuzzy/NOTICE
@@ -1,0 +1,6 @@
+This package is a Go translation of the Decentralized Identity Foundation
+fuzzy-encryption reference implementation at commit
+0d7205c7a444d1c4d17f57e0a706f756c1141dde.
+Original project: https://github.com/decentralized-identity/fuzzy-encryption
+Modifications include Go-native serialization, bounded input validation, and
+integration with SAT20 account-recovery key wrapping.

--- a/sdk/account/fuzzy/codec.go
+++ b/sdk/account/fuzzy/codec.go
@@ -1,0 +1,38 @@
+package fuzzy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+func MarshalVault(vault *Vault) ([]byte, error) {
+	if vault == nil || vault.validate() != nil {
+		return nil, ErrInvalidPublicPayload
+	}
+	out, err := json.Marshal(vault)
+	if err != nil || len(out) > MaxPublicPayloadSize {
+		return nil, ErrInvalidPublicPayload
+	}
+	return out, nil
+}
+
+func UnmarshalVault(data []byte) (*Vault, error) {
+	if len(data) == 0 || len(data) > MaxPublicPayloadSize {
+		return nil, ErrInvalidPublicPayload
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var vault Vault
+	if err := decoder.Decode(&vault); err != nil {
+		return nil, ErrInvalidPublicPayload
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, ErrInvalidPublicPayload
+	}
+	if err := vault.validate(); err != nil {
+		return nil, ErrInvalidPublicPayload
+	}
+	return &vault, nil
+}

--- a/sdk/account/fuzzy/fuzzy.go
+++ b/sdk/account/fuzzy/fuzzy.go
@@ -1,0 +1,217 @@
+package fuzzy
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sort"
+
+	"golang.org/x/crypto/scrypt"
+	"golang.org/x/crypto/sha3"
+)
+
+const (
+	scryptN = 1024
+	scryptR = 8
+	scryptP = 16
+)
+
+func GenerateParams(setSize, correctThreshold, corpusSize int, random io.Reader) (*Params, error) {
+	if random == nil {
+		random = rand.Reader
+	}
+	prime, err := firstPrimeGreaterThan(corpusSize)
+	if err != nil {
+		return nil, err
+	}
+	p := &Params{Version: Version, SetSize: setSize, CorrectThreshold: correctThreshold, CorpusSize: corpusSize, Prime: prime, Extractor: make([]int64, setSize), Salt: make([]byte, 32)}
+	if _, err := io.ReadFull(random, p.Salt); err != nil {
+		return nil, fmt.Errorf("generate salt: %w", err)
+	}
+	candidates := make([]int64, int(prime))
+	for i := range candidates {
+		candidates[i] = int64(i)
+	}
+	buf := make([]byte, 4)
+	for i := 0; i < setSize; i++ {
+		if _, err := io.ReadFull(random, buf); err != nil {
+			return nil, fmt.Errorf("generate extractor: %w", err)
+		}
+		selected := i + int(binary.LittleEndian.Uint32(buf)%uint32(len(candidates)-i))
+		p.Extractor[i] = candidates[selected]
+		candidates[selected] = candidates[i]
+	}
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func Lock(params *Params, featureIDs []int) (*Vault, error) {
+	if params == nil {
+		return nil, ErrInvalidParameters
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	features, err := normalizeFeatures(featureIDs, params.SetSize, params.CorpusSize)
+	if err != nil {
+		return nil, err
+	}
+	roots := make([]int64, len(features))
+	for i, f := range features {
+		roots[i] = int64(f)
+	}
+	poly := polyFromRoots(roots, params.Prime)
+	errorThreshold := 2 * (params.SetSize - params.CorrectThreshold)
+	start := params.SetSize - errorThreshold
+	if start < 0 || len(poly.coeffs) != params.SetSize+1 {
+		return nil, ErrInvalidParameters
+	}
+	setHash, err := slowSetHash(features, params.Salt)
+	if err != nil {
+		return nil, err
+	}
+	v := &Vault{Version: Version, SetSize: params.SetSize, CorrectThreshold: params.CorrectThreshold, CorpusSize: params.CorpusSize, Prime: params.Prime, Extractor: append([]int64(nil), params.Extractor...), Salt: append([]byte(nil), params.Salt...), Sketch: append([]int64(nil), poly.coeffs[start:params.SetSize]...), SetHash: setHash}
+	if err := v.validate(); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func RecoverKey(v *Vault, featureIDs []int, keyIndex uint32) ([]byte, error) {
+	if v == nil || v.validate() != nil {
+		return nil, ErrInvalidPublicPayload
+	}
+	features, err := normalizeFeatures(featureIDs, v.SetSize, v.CorpusSize)
+	if err != nil {
+		return nil, ErrInvalidFeatureSet
+	}
+	recovered := append([]int(nil), features...)
+	candidateHash, err := slowSetHash(recovered, v.Salt)
+	if err != nil {
+		return nil, err
+	}
+	if !hmac.Equal(candidateHash, v.SetHash) {
+		recovered, err = recoverFeatureSet(v, recovered)
+		if err != nil {
+			return nil, err
+		}
+		recoveredHash, err := slowSetHash(recovered, v.Salt)
+		if err != nil {
+			return nil, err
+		}
+		if !hmac.Equal(recoveredHash, v.SetHash) {
+			return nil, ErrInsufficientMatches
+		}
+	}
+	ek, err := extractorKey(v, recovered)
+	if err != nil {
+		return nil, err
+	}
+	defer zero(ek)
+	counter := make([]byte, 4)
+	binary.LittleEndian.PutUint32(counter, keyIndex)
+	mac := hmac.New(sha3.New512, counter)
+	_, _ = mac.Write(ek)
+	return mac.Sum(nil), nil
+}
+
+func normalizeFeatures(ids []int, expected, corpus int) ([]int, error) {
+	if len(ids) != expected {
+		return nil, ErrInvalidFeatureSet
+	}
+	out := append([]int(nil), ids...)
+	sort.Ints(out)
+	for i, value := range out {
+		if value < 0 || value >= corpus {
+			return nil, ErrInvalidFeatureSet
+		}
+		if i > 0 && out[i-1] == value {
+			return nil, ErrInvalidFeatureSet
+		}
+	}
+	return out, nil
+}
+
+func featurePass(prefix string, features []int) []byte {
+	out := make([]byte, 0, len(prefix)+4*len(features))
+	out = append(out, prefix...)
+	buf := make([]byte, 4)
+	for _, value := range features {
+		binary.LittleEndian.PutUint32(buf, uint32(value))
+		out = append(out, buf...)
+	}
+	return out
+}
+
+func slowSetHash(features []int, salt []byte) ([]byte, error) {
+	pass := featurePass("original_words:", features)
+	defer zero(pass)
+	out, err := scrypt.Key(pass, salt, scryptN, scryptR, scryptP, DefaultDerivedKeyLen)
+	if err != nil {
+		return nil, fmt.Errorf("derive set hash: %w", err)
+	}
+	return out, nil
+}
+
+func extractorKey(v *Vault, features []int) ([]byte, error) {
+	product := int64(1)
+	for i := 0; i < v.SetSize; i++ {
+		product = modMul(product, modMul(int64(features[i]), v.Extractor[i], v.Prime), v.Prime)
+	}
+	pass := []byte("key:")
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, uint32(product))
+	pass = append(pass, buf...)
+	defer zero(pass)
+	out, err := scrypt.Key(pass, v.Salt, scryptN, scryptR, scryptP, DefaultDerivedKeyLen)
+	if err != nil {
+		return nil, fmt.Errorf("derive extractor key: %w", err)
+	}
+	return out, nil
+}
+
+func recoverFeatureSet(v *Vault, candidates []int) ([]int, error) {
+	n := v.SetSize
+	errorThreshold := 2 * (v.SetSize - v.CorrectThreshold)
+	if errorThreshold%2 != 0 || errorThreshold <= 0 || errorThreshold >= n {
+		return nil, ErrInvalidPublicPayload
+	}
+	coeffs := make([]int64, n+1)
+	start := n - errorThreshold
+	copy(coeffs[start:n], v.Sketch)
+	coeffs[n] = 1
+	pHigh := newPolynomial(v.Prime, coeffs)
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i, candidate := range candidates {
+		xs[i] = int64(candidate)
+		ys[i] = pHigh.eval(xs[i])
+	}
+	pLow, err := berlekampWelch(xs, ys, n-errorThreshold, errorThreshold/2, v.Prime)
+	if err != nil {
+		return nil, ErrInsufficientMatches
+	}
+	roots, err := findRoots(pHigh.sub(pLow), n)
+	if err != nil {
+		return nil, ErrInsufficientMatches
+	}
+	out := make([]int, n)
+	for i, root := range roots {
+		if root < 0 || root >= int64(v.CorpusSize) {
+			return nil, ErrInsufficientMatches
+		}
+		out[i] = int(root)
+	}
+	sort.Ints(out)
+	return out, nil
+}
+
+func zero(value []byte) {
+	for i := range value {
+		value[i] = 0
+	}
+}

--- a/sdk/account/fuzzy/fuzzy_test.go
+++ b/sdk/account/fuzzy/fuzzy_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 The Decentralized Identity Foundation Project Authors.
+// Copyright 2026 SAT20 Labs contributors.
+// Licensed under the Apache License, Version 2.0.
+package fuzzy
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestRecoverWithinThreshold(t *testing.T) {
+	params, err := GenerateParams(9, 6, 7776, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	vault, err := Lock(params, original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := RecoverKey(vault, original, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := RecoverKey(vault, []int{1, 2, 3, 4, 5, 66, 77, 8, 99}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(want, got) {
+		t.Fatal("key mismatch")
+	}
+	if _, err := RecoverKey(vault, []int{1, 2, 3, 4, 5, 66, 77, 88, 99}, 0); !errors.Is(err, ErrInsufficientMatches) {
+		t.Fatalf("expected threshold failure, got %v", err)
+	}
+}
+
+func TestCodecRejectsMalformed(t *testing.T) {
+	for _, input := range [][]byte{nil, {1, 2, 3}, []byte(`{"version":1}`), bytes.Repeat([]byte{'x'}, MaxPublicPayloadSize+1)} {
+		if _, err := UnmarshalVault(input); err == nil {
+			t.Fatalf("accepted %d bytes", len(input))
+		}
+	}
+}
+
+func FuzzUnmarshalVault(f *testing.F) {
+	f.Add([]byte(`{"version":1}`))
+	f.Fuzz(func(t *testing.T, input []byte) { _, _ = UnmarshalVault(input) })
+}
+
+func TestDIFReferenceVector(t *testing.T) {
+	var randomBytes []byte
+	for _, value := range []string{
+		"3218C8B6681167BC81BBCA7523FEFCBD9533F8B31EEA493296B1E089FA0E2E04",
+		"E9DA670216EBDA73F1626012E64576C06D00D0F3A96BC9256972B4C314729D29",
+		"C765880C27EC4EED06155B85C43D35264E7DEF17FC01B8C3EDB5F0B3E2E1EFBE",
+	} {
+		decoded, err := hex.DecodeString(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		randomBytes = append(randomBytes, decoded...)
+	}
+	params, err := GenerateParams(9, 6, 7776, bytes.NewReader(randomBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if params.Prime != 7789 {
+		t.Fatalf("prime %d", params.Prime)
+	}
+	wantExtractor := []int64{5872, 5619, 3771, 5627, 6969, 4982, 7600, 6525, 7369}
+	if !reflect.DeepEqual(params.Extractor, wantExtractor) {
+		t.Fatalf("extractor %v", params.Extractor)
+	}
+	vault, err := Lock(params, []int{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSketch := []int64{7092, 3290, 961, 6128, 870, 7744}
+	if !reflect.DeepEqual(vault.Sketch, wantSketch) {
+		t.Fatalf("sketch %v", vault.Sketch)
+	}
+	if got := hex.EncodeToString(vault.SetHash); got != "4243504726b98926063b7c0aa65d32804c34076804775362819c71aa456d7157e31cb2a2e4851cd29f42839b81e64bfed7553a65b5958bbd4e8ef24c64cb9179" {
+		t.Fatalf("hash %s", got)
+	}
+	key, err := RecoverKey(vault, []int{1, 2, 3, 4, 5, 6, 7, 8, 9}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(key); got != "781c17d990bb740b6fbe15aa7a69bac2e57dc8868dac36fcb5732bda6100a105af251a1f34c43ecbd1c3fac5609e66bb1a6dc658eed3aebca0923f2d14ea7a89" {
+		t.Fatalf("key %s", got)
+	}
+}

--- a/sdk/account/fuzzy/math.go
+++ b/sdk/account/fuzzy/math.go
@@ -1,0 +1,283 @@
+package fuzzy
+
+import "fmt"
+
+func mod(value, prime int64) int64 {
+	value %= prime
+	if value < 0 {
+		value += prime
+	}
+	return value
+}
+func modAdd(a, b, p int64) int64 { return mod(a+b, p) }
+func modSub(a, b, p int64) int64 { return mod(a-b, p) }
+func modMul(a, b, p int64) int64 { return mod(a*b, p) }
+func modPow(a, e, p int64) int64 {
+	r := int64(1)
+	a = mod(a, p)
+	for e > 0 {
+		if e&1 == 1 {
+			r = modMul(r, a, p)
+		}
+		a = modMul(a, a, p)
+		e >>= 1
+	}
+	return r
+}
+func modInv(a, p int64) (int64, error) {
+	a = mod(a, p)
+	if a == 0 {
+		return 0, fmt.Errorf("division by zero")
+	}
+	return modPow(a, p-2, p), nil
+}
+func isPrime(n int64) bool {
+	if n < 2 {
+		return false
+	}
+	if n == 2 || n == 3 {
+		return true
+	}
+	if n%2 == 0 || n%3 == 0 {
+		return false
+	}
+	for i := int64(5); i*i <= n; i += 6 {
+		if n%i == 0 || n%(i+2) == 0 {
+			return false
+		}
+	}
+	return true
+}
+func firstPrimeGreaterThan(n int) (int64, error) {
+	if n < 1 || n >= 1_000_000 {
+		return 0, ErrInvalidParameters
+	}
+	for p := int64(n + 1); p <= 1_000_003; p++ {
+		if isPrime(p) {
+			return p, nil
+		}
+	}
+	return 0, ErrInvalidParameters
+}
+
+type polynomial struct {
+	prime  int64
+	coeffs []int64
+}
+
+func newPolynomial(p int64, c []int64) polynomial {
+	out := append([]int64(nil), c...)
+	for i := range out {
+		out[i] = mod(out[i], p)
+	}
+	q := polynomial{p, out}
+	q.trim()
+	return q
+}
+func (p *polynomial) trim() {
+	for len(p.coeffs) > 0 && p.coeffs[len(p.coeffs)-1] == 0 {
+		p.coeffs = p.coeffs[:len(p.coeffs)-1]
+	}
+}
+func (p polynomial) degree() int { return len(p.coeffs) - 1 }
+func (p polynomial) eval(x int64) int64 {
+	r := int64(0)
+	for i := len(p.coeffs) - 1; i >= 0; i-- {
+		r = modAdd(modMul(r, x, p.prime), p.coeffs[i], p.prime)
+	}
+	return r
+}
+func (p polynomial) sub(q polynomial) polynomial {
+	n := len(p.coeffs)
+	if len(q.coeffs) > n {
+		n = len(q.coeffs)
+	}
+	c := make([]int64, n)
+	for i := 0; i < n; i++ {
+		var a, b int64
+		if i < len(p.coeffs) {
+			a = p.coeffs[i]
+		}
+		if i < len(q.coeffs) {
+			b = q.coeffs[i]
+		}
+		c[i] = modSub(a, b, p.prime)
+	}
+	return newPolynomial(p.prime, c)
+}
+func (p polynomial) mul(q polynomial) polynomial {
+	if p.degree() < 0 || q.degree() < 0 {
+		return newPolynomial(p.prime, nil)
+	}
+	c := make([]int64, len(p.coeffs)+len(q.coeffs)-1)
+	for i, a := range p.coeffs {
+		for j, b := range q.coeffs {
+			c[i+j] = modAdd(c[i+j], modMul(a, b, p.prime), p.prime)
+		}
+	}
+	return newPolynomial(p.prime, c)
+}
+func polyFromRoots(roots []int64, p int64) polynomial {
+	q := newPolynomial(p, []int64{1})
+	for _, r := range roots {
+		q = q.mul(newPolynomial(p, []int64{-r, 1}))
+	}
+	return q
+}
+func divRemPolynomial(n, d polynomial) (polynomial, polynomial, error) {
+	if d.degree() < 0 {
+		return polynomial{}, polynomial{}, fmt.Errorf("divide by zero polynomial")
+	}
+	if n.degree() < d.degree() {
+		return newPolynomial(n.prime, nil), n, nil
+	}
+	q := make([]int64, n.degree()-d.degree()+1)
+	r := newPolynomial(n.prime, n.coeffs)
+	inv, err := modInv(d.coeffs[d.degree()], n.prime)
+	if err != nil {
+		return polynomial{}, polynomial{}, err
+	}
+	for r.degree() >= d.degree() {
+		shift := r.degree() - d.degree()
+		factor := modMul(r.coeffs[r.degree()], inv, n.prime)
+		q[shift] = factor
+		for i := 0; i <= d.degree(); i++ {
+			idx := i + shift
+			r.coeffs[idx] = modSub(r.coeffs[idx], modMul(factor, d.coeffs[i], n.prime), n.prime)
+		}
+		r.trim()
+	}
+	return newPolynomial(n.prime, q), r, nil
+}
+func findRoots(p polynomial, expected int) ([]int64, error) {
+	if p.degree() != expected {
+		return nil, ErrInsufficientMatches
+	}
+	roots := make([]int64, 0, expected)
+	for x := int64(0); x < p.prime; x++ {
+		if p.eval(x) == 0 {
+			roots = append(roots, x)
+		}
+	}
+	if len(roots) != expected {
+		return nil, ErrInsufficientMatches
+	}
+	return roots, nil
+}
+func powers(x int64, n int, p int64) []int64 {
+	out := make([]int64, n)
+	if n == 0 {
+		return out
+	}
+	out[0] = 1
+	for i := 1; i < n; i++ {
+		out[i] = modMul(out[i-1], x, p)
+	}
+	return out
+}
+
+func solveLinear(a [][]int64, b []int64, p int64) ([]int64, error) {
+	rows := len(a)
+	if rows == 0 || len(b) != rows {
+		return nil, ErrInsufficientMatches
+	}
+	cols := len(a[0])
+	aug := make([][]int64, rows)
+	for i := range a {
+		if len(a[i]) != cols {
+			return nil, ErrInsufficientMatches
+		}
+		aug[i] = make([]int64, cols+1)
+		for j := 0; j < cols; j++ {
+			aug[i][j] = mod(a[i][j], p)
+		}
+		aug[i][cols] = mod(b[i], p)
+	}
+	pivotRow := 0
+	pivots := make([]int, 0, cols)
+	for col := 0; col < cols && pivotRow < rows; col++ {
+		sel := -1
+		for r := pivotRow; r < rows; r++ {
+			if aug[r][col] != 0 {
+				sel = r
+				break
+			}
+		}
+		if sel < 0 {
+			continue
+		}
+		aug[pivotRow], aug[sel] = aug[sel], aug[pivotRow]
+		inv, err := modInv(aug[pivotRow][col], p)
+		if err != nil {
+			return nil, ErrInsufficientMatches
+		}
+		for j := col; j <= cols; j++ {
+			aug[pivotRow][j] = modMul(aug[pivotRow][j], inv, p)
+		}
+		for r := 0; r < rows; r++ {
+			if r == pivotRow {
+				continue
+			}
+			f := aug[r][col]
+			if f == 0 {
+				continue
+			}
+			for j := col; j <= cols; j++ {
+				aug[r][j] = modSub(aug[r][j], modMul(f, aug[pivotRow][j], p), p)
+			}
+		}
+		pivots = append(pivots, col)
+		pivotRow++
+	}
+	for r := 0; r < rows; r++ {
+		allZero := true
+		for c := 0; c < cols; c++ {
+			if aug[r][c] != 0 {
+				allZero = false
+				break
+			}
+		}
+		if allZero && aug[r][cols] != 0 {
+			return nil, ErrInsufficientMatches
+		}
+	}
+	x := make([]int64, cols)
+	for row, col := range pivots {
+		x[col] = aug[row][cols]
+	}
+	return x, nil
+}
+
+func berlekampWelch(xs, ys []int64, k, errors int, p int64) (polynomial, error) {
+	n := len(xs)
+	if n == 0 || n != len(ys) || k <= 0 || errors <= 0 || n != k+2*errors {
+		return polynomial{}, ErrInsufficientMatches
+	}
+	qCount := k + errors
+	m := make([][]int64, n)
+	rhs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		m[i] = make([]int64, n)
+		ap := powers(xs[i], qCount, p)
+		copy(m[i][:qCount], ap)
+		ep := powers(xs[i], errors+1, p)
+		for j := 0; j < errors; j++ {
+			m[i][qCount+j] = mod(-modMul(ys[i], ep[j], p), p)
+		}
+		rhs[i] = modMul(ys[i], ep[errors], p)
+	}
+	solution, err := solveLinear(m, rhs, p)
+	if err != nil {
+		return polynomial{}, err
+	}
+	q := newPolynomial(p, solution[:qCount])
+	ec := make([]int64, errors+1)
+	copy(ec, solution[qCount:])
+	ec[errors] = 1
+	e := newPolynomial(p, ec)
+	quotient, remainder, err := divRemPolynomial(q, e)
+	if err != nil || remainder.degree() >= 0 {
+		return polynomial{}, ErrInsufficientMatches
+	}
+	return quotient, nil
+}

--- a/sdk/account/fuzzy/types.go
+++ b/sdk/account/fuzzy/types.go
@@ -59,7 +59,9 @@ func (p Params) validate() error {
 	}
 	seen := make(map[int64]struct{}, len(p.Extractor))
 	for _, value := range p.Extractor {
-		if value < 0 || value >= p.Prime {
+		// Zero would collapse the multiplicative extractor key for every set
+		// containing that position, so production parameters exclude it.
+		if value <= 0 || value >= p.Prime {
 			return ErrInvalidParameters
 		}
 		if _, ok := seen[value]; ok {

--- a/sdk/account/fuzzy/types.go
+++ b/sdk/account/fuzzy/types.go
@@ -1,0 +1,88 @@
+// Package fuzzy implements a finite-field secure-sketch based fuzzy key
+// recovery scheme. It is a Go translation of the Decentralized Identity
+// Foundation fuzzy-encryption reference implementation at commit
+// 0d7205c7a444d1c4d17f57e0a706f756c1141dde (Apache-2.0).
+package fuzzy
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	Version              = 1
+	DefaultSetSize       = 16
+	DefaultThreshold     = 11
+	DefaultCorpusSize    = 32768
+	DefaultDerivedKeyLen = 64
+	MaxPublicPayloadSize = 64 * 1024
+)
+
+var (
+	ErrInvalidParameters    = errors.New("invalid fuzzy recovery parameters")
+	ErrInvalidFeatureSet    = errors.New("invalid fuzzy recovery feature set")
+	ErrInsufficientMatches  = errors.New("fuzzy recovery input does not meet the threshold")
+	ErrInvalidPublicPayload = errors.New("invalid fuzzy recovery public payload")
+)
+
+type Params struct {
+	Version          uint32  `json:"version"`
+	SetSize          int     `json:"set_size"`
+	CorrectThreshold int     `json:"correct_threshold"`
+	CorpusSize       int     `json:"corpus_size"`
+	Prime            int64   `json:"prime"`
+	Extractor        []int64 `json:"extractor"`
+	Salt             []byte  `json:"salt"`
+}
+
+type Vault struct {
+	Version          uint32  `json:"version"`
+	SetSize          int     `json:"set_size"`
+	CorrectThreshold int     `json:"correct_threshold"`
+	CorpusSize       int     `json:"corpus_size"`
+	Prime            int64   `json:"prime"`
+	Extractor        []int64 `json:"extractor"`
+	Salt             []byte  `json:"salt"`
+	Sketch           []int64 `json:"sketch"`
+	SetHash          []byte  `json:"set_hash"`
+}
+
+func (p Params) validate() error {
+	errorThreshold := 2 * (p.SetSize - p.CorrectThreshold)
+	if p.Version != Version || p.SetSize < 2 || p.SetSize > 64 ||
+		p.CorrectThreshold < 2 || p.CorrectThreshold > p.SetSize ||
+		p.CorpusSize < p.SetSize || p.CorpusSize > 1_000_000 ||
+		p.Prime <= int64(p.CorpusSize) || !isPrime(p.Prime) ||
+		len(p.Extractor) != p.SetSize || len(p.Salt) != 32 ||
+		errorThreshold <= 0 || errorThreshold >= p.SetSize {
+		return ErrInvalidParameters
+	}
+	seen := make(map[int64]struct{}, len(p.Extractor))
+	for _, value := range p.Extractor {
+		if value < 0 || value >= p.Prime {
+			return ErrInvalidParameters
+		}
+		if _, ok := seen[value]; ok {
+			return fmt.Errorf("%w: duplicate extractor", ErrInvalidParameters)
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+
+func (v Vault) validate() error {
+	params := Params{Version: v.Version, SetSize: v.SetSize, CorrectThreshold: v.CorrectThreshold,
+		CorpusSize: v.CorpusSize, Prime: v.Prime, Extractor: v.Extractor, Salt: v.Salt}
+	if err := params.validate(); err != nil {
+		return ErrInvalidPublicPayload
+	}
+	if len(v.Sketch) != 2*(v.SetSize-v.CorrectThreshold) || len(v.SetHash) != DefaultDerivedKeyLen {
+		return ErrInvalidPublicPayload
+	}
+	for _, coefficient := range v.Sketch {
+		if coefficient < 0 || coefficient >= v.Prime {
+			return ErrInvalidPublicPayload
+		}
+	}
+	return nil
+}

--- a/sdk/account/guardian.go
+++ b/sdk/account/guardian.go
@@ -1,0 +1,112 @@
+package account
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+func GenerateGuardianKey(random io.Reader) (privateKey, publicKey []byte, err error) {
+	if random == nil {
+		random = rand.Reader
+	}
+	key, err := ecdh.X25519().GenerateKey(random)
+	if err != nil {
+		return nil, nil, err
+	}
+	return append([]byte(nil), key.Bytes()...), append([]byte(nil), key.PublicKey().Bytes()...), nil
+}
+
+func guardianAAD(packageID, shareID string) []byte {
+	return []byte("sat20-guardian-share-v1|" + packageID + "|" + shareID)
+}
+func guardianKey(shared []byte, packageID, shareID string) []byte {
+	return hkdfSHA256(shared, []byte(packageID), []byte("sat20-guardian-wrap-v1|"+shareID), 32)
+}
+func validateGuardianCapsule(value GuardianShareCapsule) error {
+	if value.Version != Version || !validHex(value.PackageID, 32) || !validHex(value.ShareID, 16) || value.Algorithm != "x25519-aes-256-gcm" || value.EphemeralPublicKey == "" || value.Nonce == "" || value.Ciphertext == "" {
+		return ErrInvalidRecoveryPackage
+	}
+	return nil
+}
+
+func EncryptGuardianShare(share RecoveryShare, guardianPublicKey []byte, random io.Reader) (GuardianShareCapsule, error) {
+	if _, err := validateShare(share); err != nil || share.Role != ShareRoleGuardian {
+		return GuardianShareCapsule{}, ErrInvalidShare
+	}
+	if random == nil {
+		random = rand.Reader
+	}
+	curve := ecdh.X25519()
+	recipient, err := curve.NewPublicKey(guardianPublicKey)
+	if err != nil {
+		return GuardianShareCapsule{}, fmt.Errorf("invalid guardian public key")
+	}
+	ephemeral, err := curve.GenerateKey(random)
+	if err != nil {
+		return GuardianShareCapsule{}, err
+	}
+	shared, err := ephemeral.ECDH(recipient)
+	if err != nil {
+		return GuardianShareCapsule{}, err
+	}
+	defer zero(shared)
+	key := guardianKey(shared, share.PackageID, share.Checksum)
+	defer zero(key)
+	plaintext, err := json.Marshal(share)
+	if err != nil {
+		return GuardianShareCapsule{}, err
+	}
+	defer zero(plaintext)
+	nonce, ciphertext, err := sealBytes(key, plaintext, guardianAAD(share.PackageID, share.Checksum), random)
+	if err != nil {
+		return GuardianShareCapsule{}, err
+	}
+	capsule := GuardianShareCapsule{Version: Version, PackageID: share.PackageID, ShareID: share.Checksum, Algorithm: "x25519-aes-256-gcm", EphemeralPublicKey: base64.RawURLEncoding.EncodeToString(ephemeral.PublicKey().Bytes()), Nonce: nonce, Ciphertext: ciphertext}
+	if err := validateGuardianCapsule(capsule); err != nil {
+		return GuardianShareCapsule{}, err
+	}
+	return capsule, nil
+}
+
+func DecryptGuardianShare(capsule GuardianShareCapsule, guardianPrivateKey []byte) (RecoveryShare, error) {
+	if err := validateGuardianCapsule(capsule); err != nil {
+		return RecoveryShare{}, err
+	}
+	curve := ecdh.X25519()
+	privateKey, err := curve.NewPrivateKey(guardianPrivateKey)
+	if err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	ephemeralBytes, err := base64.RawURLEncoding.DecodeString(capsule.EphemeralPublicKey)
+	if err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	ephemeral, err := curve.NewPublicKey(ephemeralBytes)
+	if err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	shared, err := privateKey.ECDH(ephemeral)
+	if err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	defer zero(shared)
+	key := guardianKey(shared, capsule.PackageID, capsule.ShareID)
+	defer zero(key)
+	plaintext, err := openSealed(key, capsule.Nonce, capsule.Ciphertext, guardianAAD(capsule.PackageID, capsule.ShareID))
+	if err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	defer zero(plaintext)
+	var share RecoveryShare
+	if err := json.Unmarshal(plaintext, &share); err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	if _, err := validateShare(share); err != nil || share.PackageID != capsule.PackageID || share.Checksum != capsule.ShareID || share.Role != ShareRoleGuardian {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	return share, nil
+}

--- a/sdk/account/guardian_test.go
+++ b/sdk/account/guardian_test.go
@@ -1,0 +1,28 @@
+package account
+
+import "testing"
+
+func TestGuardianCapsuleRejectsWrongKey(t *testing.T) {
+	privateKey, publicKey, err := GenerateGuardianKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shares, err := splitSecret(make([]byte, 32), "00112233445566778899aabbccddeeff", RecoveryMode2Of3, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capsule, err := EncryptGuardianShare(shares[2], publicKey, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecryptGuardianShare(capsule, privateKey); err != nil {
+		t.Fatal(err)
+	}
+	wrongPrivateKey, _, err := GenerateGuardianKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecryptGuardianShare(capsule, wrongPrivateKey); err == nil {
+		t.Fatal("wrong key decrypted guardian share")
+	}
+}

--- a/sdk/account/internal/shamir/shamir.go
+++ b/sdk/account/internal/shamir/shamir.go
@@ -1,0 +1,153 @@
+// Package shamir implements Shamir secret sharing over GF(2^8).
+// Share coordinates are public and fixed to 1..N; polynomial coefficients are
+// generated from a cryptographically secure random source.
+package shamir
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"fmt"
+	"io"
+)
+
+const ShareOverhead = 1
+
+type polynomial struct{ coefficients []byte }
+
+func makePolynomial(intercept byte, degree int, random io.Reader) (polynomial, error) {
+	if degree < 1 || degree > 254 {
+		return polynomial{}, fmt.Errorf("invalid polynomial degree %d", degree)
+	}
+	if random == nil {
+		random = rand.Reader
+	}
+	p := polynomial{coefficients: make([]byte, degree+1)}
+	p.coefficients[0] = intercept
+	if _, err := io.ReadFull(random, p.coefficients[1:]); err != nil {
+		return polynomial{}, fmt.Errorf("generate polynomial coefficients: %w", err)
+	}
+	return p, nil
+}
+
+func (p polynomial) evaluate(x byte) byte {
+	if x == 0 {
+		return p.coefficients[0]
+	}
+	out := p.coefficients[len(p.coefficients)-1]
+	for i := len(p.coefficients) - 2; i >= 0; i-- {
+		out = add(mult(out, x), p.coefficients[i])
+	}
+	return out
+}
+
+func interpolate(xs, ys []byte, x byte) byte {
+	var result byte
+	for i := range xs {
+		basis := byte(1)
+		for j := range xs {
+			if i == j {
+				continue
+			}
+			basis = mult(basis, div(add(x, xs[j]), add(xs[i], xs[j])))
+		}
+		result = add(result, mult(ys[i], basis))
+	}
+	return result
+}
+
+func div(a, b byte) byte {
+	if b == 0 {
+		panic("shamir: divide by zero")
+	}
+	ret := int(mult(a, inverse(b)))
+	ret = subtle.ConstantTimeSelect(subtle.ConstantTimeByteEq(a, 0), 0, ret)
+	return byte(ret)
+}
+
+func inverse(a byte) byte {
+	b := mult(a, a)
+	c := mult(a, b)
+	b = mult(c, c)
+	b = mult(b, b)
+	c = mult(b, c)
+	b = mult(b, b)
+	b = mult(b, b)
+	b = mult(b, c)
+	b = mult(b, b)
+	b = mult(a, b)
+	return mult(b, b)
+}
+
+func mult(a, b byte) byte {
+	var r byte
+	for i := byte(8); i > 0; i-- {
+		bit := i - 1
+		r = (-(b>>bit&1) & a) ^ (-(r>>7) & 0x1B) ^ (r + r)
+	}
+	return r
+}
+func add(a, b byte) byte { return a ^ b }
+
+func Split(secret []byte, parts, threshold int, random io.Reader) ([][]byte, error) {
+	if len(secret) == 0 {
+		return nil, fmt.Errorf("cannot split an empty secret")
+	}
+	if threshold < 2 || threshold > 255 || parts < threshold || parts > 255 {
+		return nil, fmt.Errorf("invalid Shamir parts/threshold")
+	}
+	if random == nil {
+		random = rand.Reader
+	}
+	out := make([][]byte, parts)
+	for i := range out {
+		out[i] = make([]byte, len(secret)+1)
+		out[i][len(secret)] = byte(i + 1)
+	}
+	for byteIndex, value := range secret {
+		p, err := makePolynomial(value, threshold-1, random)
+		if err != nil {
+			return nil, err
+		}
+		for shareIndex := 0; shareIndex < parts; shareIndex++ {
+			out[shareIndex][byteIndex] = p.evaluate(byte(shareIndex + 1))
+		}
+	}
+	return out, nil
+}
+
+func Combine(parts [][]byte) ([]byte, error) {
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("at least two shares are required")
+	}
+	partLen := len(parts[0])
+	if partLen < 2 {
+		return nil, fmt.Errorf("invalid share length")
+	}
+	for _, part := range parts[1:] {
+		if len(part) != partLen {
+			return nil, fmt.Errorf("all shares must have equal length")
+		}
+	}
+	xs := make([]byte, len(parts))
+	seen := make(map[byte]struct{}, len(parts))
+	for i, part := range parts {
+		x := part[partLen-1]
+		if x == 0 {
+			return nil, fmt.Errorf("share index must be non-zero")
+		}
+		if _, ok := seen[x]; ok {
+			return nil, fmt.Errorf("duplicate share index")
+		}
+		seen[x] = struct{}{}
+		xs[i] = x
+	}
+	secret := make([]byte, partLen-1)
+	ys := make([]byte, len(parts))
+	for byteIndex := range secret {
+		for i, part := range parts {
+			ys[i] = part[byteIndex]
+		}
+		secret[byteIndex] = interpolate(xs, ys, 0)
+	}
+	return secret, nil
+}

--- a/sdk/account/internal/shamir/shamir.go
+++ b/sdk/account/internal/shamir/shamir.go
@@ -82,7 +82,7 @@ func mult(a, b byte) byte {
 	var r byte
 	for i := byte(8); i > 0; i-- {
 		bit := i - 1
-		r = (-(b>>bit&1) & a) ^ (-(r>>7) & 0x1B) ^ (r + r)
+		r = (-(b >> bit & 1) & a) ^ (-(r >> 7) & 0x1B) ^ (r + r)
 	}
 	return r
 }

--- a/sdk/account/internal/shamir/shamir_test.go
+++ b/sdk/account/internal/shamir/shamir_test.go
@@ -1,0 +1,27 @@
+package shamir
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+func TestAnyTwoOfThree(t *testing.T) {
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	shares, err := Split(secret, 3, 2, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pair := range [][2]int{{0, 1}, {0, 2}, {1, 2}} {
+		got, err := Combine([][]byte{shares[pair[0]], shares[pair[1]]})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, secret) {
+			t.Fatalf("pair %v mismatch", pair)
+		}
+	}
+	if _, err := Combine([][]byte{shares[0], shares[0]}); err == nil {
+		t.Fatal("duplicate share accepted")
+	}
+}

--- a/sdk/account/manager.go
+++ b/sdk/account/manager.go
@@ -1,0 +1,236 @@
+package account
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"time"
+)
+
+type Manager struct {
+	repository Repository
+	random     io.Reader
+	now        func() time.Time
+}
+
+func NewManager(repository Repository) *Manager {
+	return &Manager{repository: repository, random: rand.Reader, now: time.Now}
+}
+
+func NewManagerWithRandom(repository Repository, random io.Reader) *Manager {
+	manager := NewManager(repository)
+	if random != nil {
+		manager.random = random
+	}
+	return manager
+}
+
+func randomHex(random io.Reader, size int) (string, error) {
+	value := make([]byte, size)
+	if _, err := io.ReadFull(random, value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}
+
+func (m *Manager) CreateRecoveryPackage(options CreateOptions) (*RecoveryPackage, error) {
+	if m == nil {
+		return nil, ErrInvalidRecoveryPackage
+	}
+	if !validHex(options.AccountID, 64) {
+		return nil, ErrInvalidAccountID
+	}
+	backup, err := NormalizeBackup(options.Backup)
+	if err != nil {
+		return nil, err
+	}
+	if options.RecoveryMode != RecoveryMode2Of2 && options.RecoveryMode != RecoveryMode2Of3 {
+		return nil, ErrInvalidRecoveryPackage
+	}
+	if len(options.Questions) != knowledgeQuestionCount {
+		return nil, fmt.Errorf("three knowledge questions are required")
+	}
+	if options.RecoveryMode == RecoveryMode2Of3 && (len(options.GuardianPublicKey) != 32 || !validHex(options.GuardianMailboxID, 64)) {
+		return nil, fmt.Errorf("guardian mailbox and X25519 public key are required")
+	}
+	packageID, err := randomHex(m.random, 16)
+	if err != nil {
+		return nil, err
+	}
+	locator := Locator{Version: Version, AccountID: options.AccountID, PackageID: packageID, RecoveryMode: options.RecoveryMode}
+	secret := make([]byte, accountSecretSize)
+	if _, err := io.ReadFull(m.random, secret); err != nil {
+		return nil, err
+	}
+	defer zero(secret)
+	shares, err := splitSecret(secret, packageID, options.RecoveryMode, m.random)
+	if err != nil {
+		return nil, err
+	}
+	encrypted, err := encryptBackup(secret, locator, backup, m.random)
+	if err != nil {
+		return nil, err
+	}
+	envelope := Envelope{Version: Version, Locator: locator, EncryptedBackup: encrypted}
+	dkvsCapsule, knowledge, err := createKnowledgeRecovery(packageID, shares[1], options.Questions, m.random)
+	if err != nil {
+		return nil, err
+	}
+	envelopeHash, err := HashEnvelope(envelope)
+	if err != nil {
+		return nil, err
+	}
+	manifest := Manifest{Version: Version, Locator: locator, Threshold: 2, Total: uint8(len(shares)), EnvelopeHash: envelopeHash, CreatedAt: m.now().UnixMilli()}
+	result := &RecoveryPackage{Envelope: envelope, Manifest: manifest, UserShare: shares[0], DKVSShareCapsule: dkvsCapsule, KnowledgeBundle: knowledge}
+	if options.RecoveryMode == RecoveryMode2Of3 {
+		capsule, err := EncryptGuardianShare(shares[2], options.GuardianPublicKey, m.random)
+		if err != nil {
+			return nil, err
+		}
+		hash, err := HashGuardianCapsule(capsule)
+		if err != nil {
+			return nil, err
+		}
+		manifest.Guardian = &GuardianReference{MailboxID: options.GuardianMailboxID, ShareID: capsule.ShareID, CapsuleHash: hash}
+		result.Manifest = manifest
+		result.GuardianCapsule = &capsule
+	}
+	if err := ValidateRecoveryPackage(*result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func ValidateRecoveryPackage(value RecoveryPackage) error {
+	if err := validateEnvelope(value.Envelope); err != nil {
+		return err
+	}
+	if err := validateManifest(value.Manifest, value.Envelope.Locator); err != nil {
+		return err
+	}
+	hash, err := HashEnvelope(value.Envelope)
+	if err != nil || hash != value.Manifest.EnvelopeHash {
+		return ErrInvalidRecoveryPackage
+	}
+	if _, err := validateShare(value.UserShare); err != nil || value.UserShare.Role != ShareRoleUser || value.UserShare.PackageID != value.Envelope.Locator.PackageID {
+		return ErrInvalidRecoveryPackage
+	}
+	if value.DKVSShareCapsule.Version != Version || value.DKVSShareCapsule.PackageID != value.Envelope.Locator.PackageID || value.KnowledgeBundle.PackageID != value.Envelope.Locator.PackageID {
+		return ErrInvalidRecoveryPackage
+	}
+	if value.Envelope.Locator.RecoveryMode == RecoveryMode2Of3 {
+		if value.GuardianCapsule == nil || value.Manifest.Guardian == nil {
+			return ErrInvalidRecoveryPackage
+		}
+		hash, err := HashGuardianCapsule(*value.GuardianCapsule)
+		if err != nil || hash != value.Manifest.Guardian.CapsuleHash || value.GuardianCapsule.ShareID != value.Manifest.Guardian.ShareID {
+			return ErrInvalidRecoveryPackage
+		}
+	}
+	return nil
+}
+
+func (m *Manager) Publish(ctx context.Context, value RecoveryPackage) error {
+	if m == nil || m.repository == nil {
+		return fmt.Errorf("account repository is required")
+	}
+	if err := ValidateRecoveryPackage(value); err != nil {
+		return err
+	}
+	if err := m.repository.SaveEnvelope(ctx, value.Envelope); err != nil {
+		return err
+	}
+	if err := m.repository.SaveDKVSShareCapsule(ctx, value.Envelope.Locator, value.DKVSShareCapsule); err != nil {
+		return err
+	}
+	if err := m.repository.SaveKnowledgeBundle(ctx, value.Envelope.Locator, value.KnowledgeBundle); err != nil {
+		return err
+	}
+	return m.repository.SaveManifest(ctx, value.Manifest)
+}
+
+func (m *Manager) Load(ctx context.Context, locator Locator) (*RecoveryPackage, error) {
+	if m == nil || m.repository == nil {
+		return nil, fmt.Errorf("account repository is required")
+	}
+	if err := ValidateLocator(locator); err != nil {
+		return nil, err
+	}
+	envelope, err := m.repository.LoadEnvelope(ctx, locator)
+	if err != nil {
+		return nil, err
+	}
+	capsule, err := m.repository.LoadDKVSShareCapsule(ctx, locator)
+	if err != nil {
+		return nil, err
+	}
+	bundle, err := m.repository.LoadKnowledgeBundle(ctx, locator)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := m.repository.LoadManifest(ctx, locator)
+	if err != nil {
+		return nil, err
+	}
+	result := &RecoveryPackage{Envelope: *envelope, Manifest: *manifest, DKVSShareCapsule: *capsule, KnowledgeBundle: *bundle}
+	hash, err := HashEnvelope(*envelope)
+	if err != nil || hash != manifest.EnvelopeHash {
+		return nil, ErrInvalidRecoveryPackage
+	}
+	return result, nil
+}
+
+func RecoverAccount(envelope Envelope, shares ...RecoveryShare) (Backup, []byte, error) {
+	if err := validateEnvelope(envelope); err != nil {
+		return Backup{}, nil, err
+	}
+	secret, err := CombineShares(shares...)
+	if err != nil {
+		return Backup{}, nil, err
+	}
+	backup, err := decryptBackup(secret, envelope.Locator, envelope.EncryptedBackup)
+	if err != nil {
+		zero(secret)
+		return Backup{}, nil, err
+	}
+	return backup, secret, nil
+}
+
+func RecoverDKVSShare(capsule DKVSShareCapsule, bundle KnowledgeRecoveryBundle, answers []AnswerAttempt) (RecoveryShare, error) {
+	return recoverDKVSShare(capsule, bundle, answers)
+}
+
+func RecoverWithKnowledge(envelope Envelope, capsule DKVSShareCapsule, bundle KnowledgeRecoveryBundle, answers []AnswerAttempt, companion RecoveryShare) (Backup, []byte, error) {
+	dkvsShare, err := recoverDKVSShare(capsule, bundle, answers)
+	if err != nil {
+		return Backup{}, nil, err
+	}
+	return RecoverAccount(envelope, dkvsShare, companion)
+}
+
+func RestoreOnNewDevice(options NewDeviceRecoveryOptions) (RecoverySummary, error) {
+	backup, secret, err := RecoverAccount(options.Envelope, options.Shares...)
+	if err != nil {
+		return RecoverySummary{}, err
+	}
+	defer zero(secret)
+	summary := SummarizeBackup(options.Envelope.Locator, backup)
+	if options.Confirm == nil || options.Persist == nil {
+		return RecoverySummary{}, fmt.Errorf("confirm and persist callbacks are required")
+	}
+	ok, err := options.Confirm(summary)
+	if err != nil {
+		return RecoverySummary{}, err
+	}
+	if !ok {
+		return RecoverySummary{}, fmt.Errorf("new-device recovery was not confirmed")
+	}
+	secretCopy := append([]byte(nil), secret...)
+	defer zero(secretCopy)
+	if err := options.Persist(secretCopy, backup); err != nil {
+		return RecoverySummary{}, err
+	}
+	return summary, nil
+}

--- a/sdk/account/manager_test.go
+++ b/sdk/account/manager_test.go
@@ -1,0 +1,88 @@
+package account
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func testBackup() Backup {
+	return Backup{Version: Version, Wallets: []WalletBackup{{Name: "Primary", Mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", AccountCount: 2, SubAccounts: []SubAccount{{Index: 0, DID: "alice"}, {Index: 1, DID: "alice-work"}}}}}
+}
+
+func testQuestions() []QuestionAnswer {
+	return []QuestionAnswer{
+		{Question: KnowledgeQuestion{ID: "book-page", Prompt: "你最喜欢的一本书指定版本第十页最后十个字是什么？", IgnorePunctuation: true}, Answer: "月光落在安静的旧桥上", Confirmation: "月光落在安静的旧桥上"},
+		{Question: KnowledgeQuestion{ID: "private-note", Prompt: "你长期保存的私人纸条中指定句子是什么？", IgnorePunctuation: true}, Answer: "yellow bicycle beside the winter river", Confirmation: "yellow bicycle beside the winter river"},
+		{Question: KnowledgeQuestion{ID: "family-phrase", Prompt: "你与家人约定但从未公开的一段话是什么？", IgnorePunctuation: true}, Answer: "周日傍晚六点在老树下见", Confirmation: "周日傍晚六点在老树下见"},
+	}
+}
+
+func TestCreateAndRecoverTwoOfThree(t *testing.T) {
+	privateKey, publicKey, err := GenerateGuardianKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(nil)
+	pkg, err := manager.CreateRecoveryPackage(CreateOptions{AccountID: strings.Repeat("a", 64), Backup: testBackup(), RecoveryMode: RecoveryMode2Of3, Questions: testQuestions(), GuardianMailboxID: strings.Repeat("b", 64), GuardianPublicKey: publicKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dkvsShare, err := RecoverDKVSShare(pkg.DKVSShareCapsule, pkg.KnowledgeBundle, []AnswerAttempt{{QuestionID: "book-page", Answer: "月光落在安静的旧桥上。"}, {QuestionID: "private-note", Answer: "yellow bicycle beside the winter river"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	guardianShare, err := DecryptGuardianShare(*pkg.GuardianCapsule, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backup, secret, err := RecoverAccount(pkg.Envelope, dkvsShare, guardianShare)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero(secret)
+	normalized, _ := NormalizeBackup(testBackup())
+	if !reflect.DeepEqual(backup, normalized) {
+		t.Fatalf("backup mismatch: %#v", backup)
+	}
+	if _, err := RecoverDKVSShare(pkg.DKVSShareCapsule, pkg.KnowledgeBundle, []AnswerAttempt{{QuestionID: "book-page", Answer: "月光落在安静的旧桥上"}}); err == nil {
+		t.Fatal("one question recovered DKVS share")
+	}
+}
+
+func TestTwoOfTwoRequiresUserShare(t *testing.T) {
+	manager := NewManager(nil)
+	pkg, err := manager.CreateRecoveryPackage(CreateOptions{AccountID: strings.Repeat("c", 64), Backup: testBackup(), RecoveryMode: RecoveryMode2Of2, Questions: testQuestions()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dkvsShare, err := RecoverDKVSShare(pkg.DKVSShareCapsule, pkg.KnowledgeBundle, []AnswerAttempt{{QuestionID: "book-page", Answer: "月光落在安静的旧桥上"}, {QuestionID: "family-phrase", Answer: "周日傍晚六点在老树下见"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, secret, err := RecoverAccount(pkg.Envelope, pkg.UserShare, dkvsShare); err != nil {
+		t.Fatal(err)
+	} else {
+		zero(secret)
+	}
+}
+
+func TestNewDeviceIsRecoveryRehearsal(t *testing.T) {
+	manager := NewManager(nil)
+	pkg, err := manager.CreateRecoveryPackage(CreateOptions{AccountID: strings.Repeat("d", 64), Backup: testBackup(), RecoveryMode: RecoveryMode2Of2, Questions: testQuestions()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dkvsShare, err := RecoverDKVSShare(pkg.DKVSShareCapsule, pkg.KnowledgeBundle, []AnswerAttempt{{QuestionID: "book-page", Answer: "月光落在安静的旧桥上"}, {QuestionID: "private-note", Answer: "yellow bicycle beside the winter river"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	confirmed, persisted := false, false
+	summary, err := RestoreOnNewDevice(NewDeviceRecoveryOptions{Envelope: pkg.Envelope, Shares: []RecoveryShare{pkg.UserShare, dkvsShare}, Confirm: func(summary RecoverySummary) (bool, error) { confirmed = true; return len(summary.Wallets) == 1, nil }, Persist: func(secret []byte, backup Backup) error { persisted = len(secret) == 32 && len(backup.Wallets) == 1; return nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !confirmed || !persisted || summary.PackageID != pkg.Envelope.Locator.PackageID {
+		t.Fatal("rehearsal callbacks not completed")
+	}
+}

--- a/sdk/account/manager_test.go
+++ b/sdk/account/manager_test.go
@@ -78,7 +78,10 @@ func TestNewDeviceIsRecoveryRehearsal(t *testing.T) {
 		t.Fatal(err)
 	}
 	confirmed, persisted := false, false
-	summary, err := RestoreOnNewDevice(NewDeviceRecoveryOptions{Envelope: pkg.Envelope, Shares: []RecoveryShare{pkg.UserShare, dkvsShare}, Confirm: func(summary RecoverySummary) (bool, error) { confirmed = true; return len(summary.Wallets) == 1, nil }, Persist: func(secret []byte, backup Backup) error { persisted = len(secret) == 32 && len(backup.Wallets) == 1; return nil }})
+	summary, err := RestoreOnNewDevice(NewDeviceRecoveryOptions{Envelope: pkg.Envelope, Shares: []RecoveryShare{pkg.UserShare, dkvsShare}, Confirm: func(summary RecoverySummary) (bool, error) { confirmed = true; return len(summary.Wallets) == 1, nil }, Persist: func(secret []byte, backup Backup) error {
+		persisted = len(secret) == 32 && len(backup.Wallets) == 1
+		return nil
+	}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/account/questions.go
+++ b/sdk/account/questions.go
@@ -1,0 +1,267 @@
+package account
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/sat20-labs/sat20wallet/sdk/account/fuzzy"
+	"github.com/sat20-labs/sat20wallet/sdk/account/internal/shamir"
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	knowledgeQuestionCount     = 3
+	knowledgeQuestionThreshold = 2
+	featureSetSize              = 24
+	featureCorrectThreshold     = 15
+	featureCorpusSize           = 65536
+)
+
+type rankedFeature struct {
+	rank [32]byte
+	id   int
+}
+
+func normalizeAnswer(question KnowledgeQuestion, value string) (string, error) {
+	value = norm.NFKC.String(value)
+	value = strings.Join(strings.Fields(value), " ")
+	if !question.CaseSensitive {
+		value = strings.ToLower(value)
+	}
+	if question.IgnorePunctuation {
+		value = strings.Map(func(r rune) rune {
+			if unicode.IsPunct(r) {
+				return -1
+			}
+			return r
+		}, value)
+	}
+	value = strings.TrimSpace(value)
+	runes := []rune(value)
+	if len(runes) < 8 || len(runes) > 256 {
+		return "", fmt.Errorf("knowledge answer must contain 8-256 characters")
+	}
+	return value, nil
+}
+
+func featureTokens(value string) []string {
+	runes := []rune("^" + value + "$")
+	tokens := make([]string, 0, len(runes)*3)
+	for i := range runes {
+		tokens = append(tokens, "u:"+string(runes[i]))
+		if i+1 < len(runes) {
+			tokens = append(tokens, "b:"+string(runes[i:i+2]))
+		}
+		if i+2 < len(runes) {
+			tokens = append(tokens, "t:"+string(runes[i:i+3]))
+		}
+	}
+	for _, word := range strings.Fields(value) {
+		tokens = append(tokens, "w:"+word)
+	}
+	return tokens
+}
+
+func featureIDs(question KnowledgeQuestion, answer string, salt []byte) ([]int, error) {
+	normalized, err := normalizeAnswer(question, answer)
+	if err != nil {
+		return nil, err
+	}
+	tokens := featureTokens(normalized)
+	ranked := make([]rankedFeature, 0, len(tokens))
+	seenToken := map[string]struct{}{}
+	seenID := map[int]struct{}{}
+	for _, token := range tokens {
+		if _, ok := seenToken[token]; ok {
+			continue
+		}
+		seenToken[token] = struct{}{}
+		mac := hmac.New(sha256.New, salt)
+		_, _ = mac.Write([]byte(question.ID))
+		_, _ = mac.Write([]byte{0})
+		_, _ = mac.Write([]byte(token))
+		digest := mac.Sum(nil)
+		var rank [32]byte
+		copy(rank[:], digest)
+		id := int(binary.BigEndian.Uint32(digest[:4]) % featureCorpusSize)
+		if _, ok := seenID[id]; ok {
+			continue
+		}
+		seenID[id] = struct{}{}
+		ranked = append(ranked, rankedFeature{rank: rank, id: id})
+	}
+	sort.Slice(ranked, func(i, j int) bool { return string(ranked[i].rank[:]) < string(ranked[j].rank[:]) })
+	if len(ranked) < featureSetSize {
+		return nil, fmt.Errorf("answer does not provide enough independent features")
+	}
+	out := make([]int, featureSetSize)
+	for i := range out {
+		out[i] = ranked[i].id
+	}
+	sort.Ints(out)
+	return out, nil
+}
+
+func questionAAD(packageID, questionID string) []byte {
+	return []byte("sat20-question-share-v1|" + packageID + "|" + questionID)
+}
+func dkvsCapsuleAAD(packageID string) []byte { return []byte("sat20-dkvs-share-v1|" + packageID) }
+func knowledgeKEK(key []byte, packageID, questionID string) []byte {
+	return hkdfSHA256(key, []byte(packageID), []byte("sat20-fuzzy-question-v1|"+questionID), 32)
+}
+
+func createKnowledgeRecovery(packageID string, dkvsShare RecoveryShare, questions []QuestionAnswer, random io.Reader) (DKVSShareCapsule, KnowledgeRecoveryBundle, error) {
+	if len(questions) != knowledgeQuestionCount {
+		return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, fmt.Errorf("exactly three recovery questions are required")
+	}
+	if random == nil {
+		random = rand.Reader
+	}
+	kDKVS := make([]byte, 32)
+	if _, err := io.ReadFull(random, kDKVS); err != nil {
+		return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+	}
+	defer zero(kDKVS)
+	questionShares, err := shamir.Split(kDKVS, knowledgeQuestionCount, knowledgeQuestionThreshold, random)
+	if err != nil {
+		return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+	}
+	bundle := KnowledgeRecoveryBundle{Version: Version, PackageID: packageID, Threshold: knowledgeQuestionThreshold, Total: knowledgeQuestionCount, QuestionShares: make([]EncryptedQuestionShare, knowledgeQuestionCount)}
+	seen := map[string]struct{}{}
+	for i, input := range questions {
+		question := input.Question
+		question.ID = normalizeSpace(question.ID)
+		question.Prompt = normalizeSpace(question.Prompt)
+		if question.ID == "" || question.Prompt == "" {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, fmt.Errorf("invalid recovery question")
+		}
+		if _, ok := seen[question.ID]; ok {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, fmt.Errorf("duplicate recovery question id")
+		}
+		seen[question.ID] = struct{}{}
+		answer, err := normalizeAnswer(question, input.Answer)
+		if err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		confirmation, err := normalizeAnswer(question, input.Confirmation)
+		if err != nil || answer != confirmation {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, fmt.Errorf("recovery answer confirmation does not match")
+		}
+		salt := make([]byte, 32)
+		if _, err := io.ReadFull(random, salt); err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		ids, err := featureIDs(question, answer, salt)
+		if err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		params, err := fuzzy.GenerateParams(featureSetSize, featureCorrectThreshold, featureCorpusSize, random)
+		if err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		vault, err := fuzzy.Lock(params, ids)
+		if err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		vaultBytes, err := fuzzy.MarshalVault(vault)
+		if err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		keyMaterial, err := fuzzy.RecoverKey(vault, ids, 0)
+		if err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		kek := knowledgeKEK(keyMaterial, packageID, question.ID)
+		zero(keyMaterial)
+		nonce, ciphertext, err := sealBytes(kek, questionShares[i], questionAAD(packageID, question.ID), random)
+		zero(kek)
+		if err != nil {
+			return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+		}
+		bundle.QuestionShares[i] = EncryptedQuestionShare{Question: question, Salt: base64.RawURLEncoding.EncodeToString(salt), Vault: vaultBytes, Nonce: nonce, Ciphertext: ciphertext}
+	}
+	shareBytes, err := json.Marshal(dkvsShare)
+	if err != nil {
+		return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+	}
+	defer zero(shareBytes)
+	nonce, ciphertext, err := sealBytes(kDKVS, shareBytes, dkvsCapsuleAAD(packageID), random)
+	if err != nil {
+		return DKVSShareCapsule{}, KnowledgeRecoveryBundle{}, err
+	}
+	return DKVSShareCapsule{Version: Version, PackageID: packageID, Algorithm: "aes-256-gcm", Nonce: nonce, Ciphertext: ciphertext}, bundle, nil
+}
+
+func recoverDKVSShare(capsule DKVSShareCapsule, bundle KnowledgeRecoveryBundle, answers []AnswerAttempt) (RecoveryShare, error) {
+	if capsule.Version != Version || bundle.Version != Version || capsule.PackageID != bundle.PackageID || bundle.Threshold != knowledgeQuestionThreshold || bundle.Total != knowledgeQuestionCount || len(bundle.QuestionShares) != knowledgeQuestionCount {
+		return RecoveryShare{}, ErrInvalidRecoveryPackage
+	}
+	answerMap := map[string]string{}
+	for _, answer := range answers {
+		answerMap[normalizeSpace(answer.QuestionID)] = answer.Answer
+	}
+	recovered := make([][]byte, 0, knowledgeQuestionThreshold)
+	for _, entry := range bundle.QuestionShares {
+		answer, ok := answerMap[entry.Question.ID]
+		if !ok {
+			continue
+		}
+		salt, err := base64.RawURLEncoding.DecodeString(entry.Salt)
+		if err != nil || len(salt) != 32 {
+			continue
+		}
+		ids, err := featureIDs(entry.Question, answer, salt)
+		if err != nil {
+			continue
+		}
+		vault, err := fuzzy.UnmarshalVault(entry.Vault)
+		if err != nil {
+			continue
+		}
+		keyMaterial, err := fuzzy.RecoverKey(vault, ids, 0)
+		if err != nil {
+			continue
+		}
+		kek := knowledgeKEK(keyMaterial, bundle.PackageID, entry.Question.ID)
+		zero(keyMaterial)
+		share, err := openSealed(kek, entry.Nonce, entry.Ciphertext, questionAAD(bundle.PackageID, entry.Question.ID))
+		zero(kek)
+		if err != nil {
+			continue
+		}
+		recovered = append(recovered, share)
+		if len(recovered) == knowledgeQuestionThreshold {
+			break
+		}
+	}
+	if len(recovered) < knowledgeQuestionThreshold {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	kDKVS, err := shamir.Combine(recovered)
+	if err != nil || len(kDKVS) != 32 {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	defer zero(kDKVS)
+	plaintext, err := openSealed(kDKVS, capsule.Nonce, capsule.Ciphertext, dkvsCapsuleAAD(bundle.PackageID))
+	if err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	defer zero(plaintext)
+	var share RecoveryShare
+	if err := json.Unmarshal(plaintext, &share); err != nil {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	if _, err := validateShare(share); err != nil || share.Role != ShareRoleDKVS || share.PackageID != bundle.PackageID {
+		return RecoveryShare{}, ErrRecoveryFailed
+	}
+	return share, nil
+}

--- a/sdk/account/questions.go
+++ b/sdk/account/questions.go
@@ -21,9 +21,9 @@ import (
 const (
 	knowledgeQuestionCount     = 3
 	knowledgeQuestionThreshold = 2
-	featureSetSize              = 24
-	featureCorrectThreshold     = 15
-	featureCorpusSize           = 65536
+	featureSetSize             = 24
+	featureCorrectThreshold    = 15
+	featureCorpusSize          = 65536
 )
 
 type rankedFeature struct {

--- a/sdk/account/questions_test.go
+++ b/sdk/account/questions_test.go
@@ -1,0 +1,48 @@
+package account
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKnowledgeRecoveryToleratesSmallAnswerError(t *testing.T) {
+	manager := NewManager(nil)
+	pkg, err := manager.CreateRecoveryPackage(CreateOptions{
+		AccountID:    strings.Repeat("e", 64),
+		Backup:       testBackup(),
+		RecoveryMode: RecoveryMode2Of2,
+		Questions:    testQuestions(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	share, err := RecoverDKVSShare(pkg.DKVSShareCapsule, pkg.KnowledgeBundle, []AnswerAttempt{
+		{QuestionID: "book-page", Answer: "月光落在安静的古桥上"},
+		{QuestionID: "private-note", Answer: "yellow bicycle beside the winter river"},
+	})
+	if err != nil {
+		t.Fatalf("small answer change should be recoverable: %v", err)
+	}
+	if share.Role != ShareRoleDKVS {
+		t.Fatalf("unexpected role %s", share.Role)
+	}
+}
+
+func TestKnowledgeRecoveryRejectsUnrelatedAnswers(t *testing.T) {
+	manager := NewManager(nil)
+	pkg, err := manager.CreateRecoveryPackage(CreateOptions{
+		AccountID:    strings.Repeat("f", 64),
+		Backup:       testBackup(),
+		RecoveryMode: RecoveryMode2Of2,
+		Questions:    testQuestions(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RecoverDKVSShare(pkg.DKVSShareCapsule, pkg.KnowledgeBundle, []AnswerAttempt{
+		{QuestionID: "book-page", Answer: "这是一个完全不同且无法匹配的回答"},
+		{QuestionID: "private-note", Answer: "another completely unrelated private answer"},
+	}); err == nil {
+		t.Fatal("unrelated answers recovered the DKVS share")
+	}
+}

--- a/sdk/account/share.go
+++ b/sdk/account/share.go
@@ -1,0 +1,145 @@
+package account
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/sat20-labs/sat20wallet/sdk/account/internal/shamir"
+)
+
+func expectedRole(total, index uint8) ShareRole {
+	if total == 2 {
+		if index == 1 {
+			return ShareRoleUser
+		}
+		if index == 2 {
+			return ShareRoleDKVS
+		}
+	}
+	if total == 3 {
+		if index == 1 {
+			return ShareRoleUser
+		}
+		if index == 2 {
+			return ShareRoleDKVS
+		}
+		if index == 3 {
+			return ShareRoleGuardian
+		}
+	}
+	return ""
+}
+
+func shareChecksum(value RecoveryShare) string {
+	copyValue := value
+	copyValue.Checksum = ""
+	encoded, _ := json.Marshal(copyValue)
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:8])
+}
+
+func newRecoveryShare(packageID string, total, index uint8, data []byte) (RecoveryShare, error) {
+	value := RecoveryShare{Version: Version, PackageID: packageID, Threshold: 2, Total: total, Index: index, Role: expectedRole(total, index), Data: base64.RawURLEncoding.EncodeToString(data)}
+	value.Checksum = shareChecksum(value)
+	_, err := validateShare(value)
+	return value, err
+}
+
+func validateShare(value RecoveryShare) ([]byte, error) {
+	if value.Version != Version || !validHex(value.PackageID, 32) || value.Threshold != 2 ||
+		(value.Total != 2 && value.Total != 3) || value.Index < 1 || value.Index > value.Total ||
+		value.Role != expectedRole(value.Total, value.Index) || !validHex(value.Checksum, 16) || shareChecksum(value) != value.Checksum {
+		return nil, ErrInvalidShare
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(value.Data)
+	if err != nil || len(raw) != accountSecretSize+shamir.ShareOverhead || raw[len(raw)-1] != value.Index {
+		return nil, ErrInvalidShare
+	}
+	return raw, nil
+}
+
+func splitSecret(secret []byte, packageID string, mode RecoveryMode, random io.Reader) ([]RecoveryShare, error) {
+	total := 2
+	if mode == RecoveryMode2Of3 {
+		total = 3
+	} else if mode != RecoveryMode2Of2 {
+		return nil, ErrInvalidRecoveryPackage
+	}
+	rawShares, err := shamir.Split(secret, total, 2, random)
+	if err != nil {
+		return nil, err
+	}
+	shares := make([]RecoveryShare, total)
+	for i := range rawShares {
+		shares[i], err = newRecoveryShare(packageID, uint8(total), uint8(i+1), rawShares[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return shares, nil
+}
+
+func CombineShares(shares ...RecoveryShare) ([]byte, error) {
+	if len(shares) < 2 {
+		return nil, ErrInsufficientShares
+	}
+	reference := shares[0]
+	seen := map[uint8]struct{}{}
+	raw := make([][]byte, 0, len(shares))
+	for _, share := range shares {
+		if share.PackageID != reference.PackageID || share.Total != reference.Total || share.Threshold != reference.Threshold {
+			return nil, ErrInvalidShare
+		}
+		if _, ok := seen[share.Index]; ok {
+			return nil, ErrInvalidShare
+		}
+		seen[share.Index] = struct{}{}
+		decoded, err := validateShare(share)
+		if err != nil {
+			return nil, err
+		}
+		raw = append(raw, decoded)
+	}
+	secret, err := shamir.Combine(raw[:2])
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrRecoveryFailed, err)
+	}
+	if len(secret) != accountSecretSize {
+		return nil, ErrRecoveryFailed
+	}
+	return secret, nil
+}
+
+func EncodeRecoveryShare(value RecoveryShare) (string, error) {
+	if _, err := validateShare(value); err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return "sat20-share-v1:" + base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func DecodeRecoveryShare(value string) (RecoveryShare, error) {
+	const prefix = "sat20-share-v1:"
+	if len(value) <= len(prefix) || value[:len(prefix)] != prefix {
+		return RecoveryShare{}, ErrInvalidShare
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(value[len(prefix):])
+	if err != nil {
+		return RecoveryShare{}, ErrInvalidShare
+	}
+	var share RecoveryShare
+	if err := json.Unmarshal(raw, &share); err != nil {
+		return RecoveryShare{}, ErrInvalidShare
+	}
+	if _, err := validateShare(share); err != nil {
+		return RecoveryShare{}, err
+	}
+	return share, nil
+}

--- a/sdk/account/types.go
+++ b/sdk/account/types.go
@@ -42,10 +42,10 @@ type SubAccount struct {
 }
 
 type WalletBackup struct {
-	Name          string       `json:"name"`
-	Mnemonic      string       `json:"mnemonic"`
-	AccountCount  uint32       `json:"account_count"`
-	SubAccounts   []SubAccount `json:"sub_accounts"`
+	Name         string       `json:"name"`
+	Mnemonic     string       `json:"mnemonic"`
+	AccountCount uint32       `json:"account_count"`
+	SubAccounts  []SubAccount `json:"sub_accounts"`
 }
 
 type Backup struct {
@@ -147,21 +147,21 @@ type Manifest struct {
 }
 
 type RecoveryPackage struct {
-	Envelope          Envelope                `json:"envelope"`
-	Manifest          Manifest                `json:"manifest"`
-	UserShare         RecoveryShare           `json:"user_share"`
-	DKVSShareCapsule  DKVSShareCapsule        `json:"dkvs_share_capsule"`
-	KnowledgeBundle   KnowledgeRecoveryBundle `json:"knowledge_bundle"`
-	GuardianCapsule   *GuardianShareCapsule   `json:"guardian_capsule,omitempty"`
+	Envelope         Envelope                `json:"envelope"`
+	Manifest         Manifest                `json:"manifest"`
+	UserShare        RecoveryShare           `json:"user_share"`
+	DKVSShareCapsule DKVSShareCapsule        `json:"dkvs_share_capsule"`
+	KnowledgeBundle  KnowledgeRecoveryBundle `json:"knowledge_bundle"`
+	GuardianCapsule  *GuardianShareCapsule   `json:"guardian_capsule,omitempty"`
 }
 
 type CreateOptions struct {
-	AccountID          string
-	Backup             Backup
-	RecoveryMode       RecoveryMode
-	Questions          []QuestionAnswer
-	GuardianMailboxID  string
-	GuardianPublicKey  []byte
+	AccountID         string
+	Backup            Backup
+	RecoveryMode      RecoveryMode
+	Questions         []QuestionAnswer
+	GuardianMailboxID string
+	GuardianPublicKey []byte
 }
 
 type AnswerAttempt struct {

--- a/sdk/account/types.go
+++ b/sdk/account/types.go
@@ -1,0 +1,201 @@
+package account
+
+import (
+	"context"
+	"errors"
+)
+
+const (
+	Version               = 1
+	accountSecretSize     = 32
+	MaxRecoveryObjectSize = 10 * 1024
+)
+
+type RecoveryMode string
+
+const (
+	RecoveryMode2Of2 RecoveryMode = "2of2"
+	RecoveryMode2Of3 RecoveryMode = "2of3"
+)
+
+type ShareRole string
+
+const (
+	ShareRoleUser     ShareRole = "user"
+	ShareRoleDKVS     ShareRole = "dkvs"
+	ShareRoleGuardian ShareRole = "guardian"
+)
+
+var (
+	ErrInvalidAccountID       = errors.New("invalid account id")
+	ErrInvalidPackageID       = errors.New("invalid recovery package id")
+	ErrInvalidBackup          = errors.New("invalid account backup")
+	ErrInvalidRecoveryPackage = errors.New("invalid recovery package")
+	ErrInvalidShare           = errors.New("invalid recovery share")
+	ErrInsufficientShares     = errors.New("insufficient recovery shares")
+	ErrRecoveryFailed         = errors.New("account recovery failed")
+)
+
+type SubAccount struct {
+	Index uint32 `json:"index"`
+	DID   string `json:"did"`
+}
+
+type WalletBackup struct {
+	Name          string       `json:"name"`
+	Mnemonic      string       `json:"mnemonic"`
+	AccountCount  uint32       `json:"account_count"`
+	SubAccounts   []SubAccount `json:"sub_accounts"`
+}
+
+type Backup struct {
+	Version uint32         `json:"version"`
+	Wallets []WalletBackup `json:"wallets"`
+}
+
+type Locator struct {
+	Version      uint32       `json:"version"`
+	AccountID    string       `json:"account_id"`
+	PackageID    string       `json:"package_id"`
+	RecoveryMode RecoveryMode `json:"recovery_mode"`
+}
+
+type EncryptedBlob struct {
+	Algorithm  string `json:"algorithm"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type Envelope struct {
+	Version         uint32        `json:"version"`
+	Locator         Locator       `json:"locator"`
+	EncryptedBackup EncryptedBlob `json:"encrypted_backup"`
+}
+
+type RecoveryShare struct {
+	Version   uint32    `json:"version"`
+	PackageID string    `json:"package_id"`
+	Threshold uint8     `json:"threshold"`
+	Total     uint8     `json:"total"`
+	Index     uint8     `json:"index"`
+	Role      ShareRole `json:"role"`
+	Data      string    `json:"data"`
+	Checksum  string    `json:"checksum"`
+}
+
+type KnowledgeQuestion struct {
+	ID                string `json:"id"`
+	Prompt            string `json:"prompt"`
+	CaseSensitive     bool   `json:"case_sensitive"`
+	IgnorePunctuation bool   `json:"ignore_punctuation"`
+}
+
+type QuestionAnswer struct {
+	Question     KnowledgeQuestion `json:"question"`
+	Answer       string            `json:"-"`
+	Confirmation string            `json:"-"`
+}
+
+type EncryptedQuestionShare struct {
+	Question   KnowledgeQuestion `json:"question"`
+	Salt       string            `json:"salt"`
+	Vault      []byte            `json:"vault"`
+	Nonce      string            `json:"nonce"`
+	Ciphertext string            `json:"ciphertext"`
+}
+
+type KnowledgeRecoveryBundle struct {
+	Version        uint32                   `json:"version"`
+	PackageID      string                   `json:"package_id"`
+	Threshold      uint8                    `json:"threshold"`
+	Total          uint8                    `json:"total"`
+	QuestionShares []EncryptedQuestionShare `json:"question_shares"`
+}
+
+type DKVSShareCapsule struct {
+	Version    uint32 `json:"version"`
+	PackageID  string `json:"package_id"`
+	Algorithm  string `json:"algorithm"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type GuardianShareCapsule struct {
+	Version            uint32 `json:"version"`
+	PackageID          string `json:"package_id"`
+	ShareID            string `json:"share_id"`
+	Algorithm          string `json:"algorithm"`
+	EphemeralPublicKey string `json:"ephemeral_public_key"`
+	Nonce              string `json:"nonce"`
+	Ciphertext         string `json:"ciphertext"`
+}
+
+type GuardianReference struct {
+	MailboxID   string `json:"mailbox_id"`
+	ShareID     string `json:"share_id"`
+	CapsuleHash string `json:"capsule_hash"`
+}
+
+type Manifest struct {
+	Version      uint32             `json:"version"`
+	Locator      Locator            `json:"locator"`
+	Threshold    uint8              `json:"threshold"`
+	Total        uint8              `json:"total"`
+	EnvelopeHash string             `json:"envelope_hash"`
+	CreatedAt    int64              `json:"created_at"`
+	Guardian     *GuardianReference `json:"guardian,omitempty"`
+}
+
+type RecoveryPackage struct {
+	Envelope          Envelope                `json:"envelope"`
+	Manifest          Manifest                `json:"manifest"`
+	UserShare         RecoveryShare           `json:"user_share"`
+	DKVSShareCapsule  DKVSShareCapsule        `json:"dkvs_share_capsule"`
+	KnowledgeBundle   KnowledgeRecoveryBundle `json:"knowledge_bundle"`
+	GuardianCapsule   *GuardianShareCapsule   `json:"guardian_capsule,omitempty"`
+}
+
+type CreateOptions struct {
+	AccountID          string
+	Backup             Backup
+	RecoveryMode       RecoveryMode
+	Questions          []QuestionAnswer
+	GuardianMailboxID  string
+	GuardianPublicKey  []byte
+}
+
+type AnswerAttempt struct {
+	QuestionID string
+	Answer     string
+}
+
+type RecoverySummary struct {
+	AccountID    string          `json:"account_id"`
+	PackageID    string          `json:"package_id"`
+	RecoveryMode RecoveryMode    `json:"recovery_mode"`
+	Wallets      []WalletSummary `json:"wallets"`
+}
+
+type WalletSummary struct {
+	Name         string   `json:"name"`
+	AccountCount uint32   `json:"account_count"`
+	DIDs         []string `json:"dids"`
+}
+
+type NewDeviceRecoveryOptions struct {
+	Envelope Envelope
+	Shares   []RecoveryShare
+	Confirm  func(RecoverySummary) (bool, error)
+	Persist  func(accountSecret []byte, backup Backup) error
+}
+
+type Repository interface {
+	SaveEnvelope(context.Context, Envelope) error
+	SaveDKVSShareCapsule(context.Context, Locator, DKVSShareCapsule) error
+	SaveKnowledgeBundle(context.Context, Locator, KnowledgeRecoveryBundle) error
+	SaveManifest(context.Context, Manifest) error
+	LoadEnvelope(context.Context, Locator) (*Envelope, error)
+	LoadDKVSShareCapsule(context.Context, Locator) (*DKVSShareCapsule, error)
+	LoadKnowledgeBundle(context.Context, Locator) (*KnowledgeRecoveryBundle, error)
+	LoadManifest(context.Context, Locator) (*Manifest, error)
+}

--- a/sdk/account/validation.go
+++ b/sdk/account/validation.go
@@ -31,7 +31,9 @@ func ValidateLocator(locator Locator) error {
 	return nil
 }
 
-func normalizeSpace(value string) string { return strings.Join(strings.Fields(strings.TrimSpace(value)), " ") }
+func normalizeSpace(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}
 
 func NormalizeBackup(value Backup) (Backup, error) {
 	if value.Version != Version || len(value.Wallets) == 0 {

--- a/sdk/account/validation.go
+++ b/sdk/account/validation.go
@@ -1,0 +1,143 @@
+package account
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	bip39 "github.com/tyler-smith/go-bip39"
+)
+
+func validHex(value string, size int) bool {
+	if len(value) != size {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && value == strings.ToLower(value)
+}
+
+func ValidateLocator(locator Locator) error {
+	if locator.Version != Version || !validHex(locator.AccountID, 64) {
+		return ErrInvalidAccountID
+	}
+	if !validHex(locator.PackageID, 32) {
+		return ErrInvalidPackageID
+	}
+	if locator.RecoveryMode != RecoveryMode2Of2 && locator.RecoveryMode != RecoveryMode2Of3 {
+		return ErrInvalidRecoveryPackage
+	}
+	return nil
+}
+
+func normalizeSpace(value string) string { return strings.Join(strings.Fields(strings.TrimSpace(value)), " ") }
+
+func NormalizeBackup(value Backup) (Backup, error) {
+	if value.Version != Version || len(value.Wallets) == 0 {
+		return Backup{}, ErrInvalidBackup
+	}
+	out := Backup{Version: Version, Wallets: make([]WalletBackup, len(value.Wallets))}
+	walletNames := map[string]struct{}{}
+	for walletIndex, wallet := range value.Wallets {
+		name := normalizeSpace(wallet.Name)
+		mnemonic := normalizeSpace(wallet.Mnemonic)
+		if name == "" || !bip39.IsMnemonicValid(mnemonic) || wallet.AccountCount == 0 || int(wallet.AccountCount) != len(wallet.SubAccounts) {
+			return Backup{}, ErrInvalidBackup
+		}
+		if _, ok := walletNames[name]; ok {
+			return Backup{}, fmt.Errorf("%w: duplicate wallet name", ErrInvalidBackup)
+		}
+		walletNames[name] = struct{}{}
+		subAccounts := append([]SubAccount(nil), wallet.SubAccounts...)
+		seenIndex := map[uint32]struct{}{}
+		seenDID := map[string]struct{}{}
+		for i := range subAccounts {
+			subAccounts[i].DID = normalizeSpace(subAccounts[i].DID)
+			if subAccounts[i].Index >= wallet.AccountCount || subAccounts[i].DID == "" {
+				return Backup{}, ErrInvalidBackup
+			}
+			if _, ok := seenIndex[subAccounts[i].Index]; ok {
+				return Backup{}, ErrInvalidBackup
+			}
+			if _, ok := seenDID[subAccounts[i].DID]; ok {
+				return Backup{}, ErrInvalidBackup
+			}
+			seenIndex[subAccounts[i].Index] = struct{}{}
+			seenDID[subAccounts[i].DID] = struct{}{}
+		}
+		for i := uint32(0); i < wallet.AccountCount; i++ {
+			if _, ok := seenIndex[i]; !ok {
+				return Backup{}, ErrInvalidBackup
+			}
+		}
+		out.Wallets[walletIndex] = WalletBackup{Name: name, Mnemonic: mnemonic, AccountCount: wallet.AccountCount, SubAccounts: subAccounts}
+	}
+	return out, nil
+}
+
+func validateEncryptedBlob(value EncryptedBlob) error {
+	if value.Algorithm != "aes-256-gcm" || value.Nonce == "" || value.Ciphertext == "" {
+		return ErrInvalidRecoveryPackage
+	}
+	return nil
+}
+
+func validateEnvelope(value Envelope) error {
+	if value.Version != Version {
+		return ErrInvalidRecoveryPackage
+	}
+	if err := ValidateLocator(value.Locator); err != nil {
+		return err
+	}
+	return validateEncryptedBlob(value.EncryptedBackup)
+}
+
+func validateManifest(value Manifest, locator Locator) error {
+	if value.Version != Version || value.Locator != locator || value.Threshold != 2 || !validHex(value.EnvelopeHash, 64) {
+		return ErrInvalidRecoveryPackage
+	}
+	expected := uint8(2)
+	if locator.RecoveryMode == RecoveryMode2Of3 {
+		expected = 3
+	}
+	if value.Total != expected {
+		return ErrInvalidRecoveryPackage
+	}
+	return nil
+}
+
+func canonicalHash(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func HashEnvelope(value Envelope) (string, error) {
+	if err := validateEnvelope(value); err != nil {
+		return "", err
+	}
+	return canonicalHash(value)
+}
+
+func HashGuardianCapsule(value GuardianShareCapsule) (string, error) {
+	if err := validateGuardianCapsule(value); err != nil {
+		return "", err
+	}
+	return canonicalHash(value)
+}
+
+func SummarizeBackup(locator Locator, backup Backup) RecoverySummary {
+	summary := RecoverySummary{AccountID: locator.AccountID, PackageID: locator.PackageID, RecoveryMode: locator.RecoveryMode, Wallets: make([]WalletSummary, len(backup.Wallets))}
+	for i, wallet := range backup.Wallets {
+		dids := make([]string, len(wallet.SubAccounts))
+		for j, subAccount := range wallet.SubAccounts {
+			dids[j] = subAccount.DID
+		}
+		summary.Wallets[i] = WalletSummary{Name: wallet.Name, AccountCount: wallet.AccountCount, DIDs: dids}
+	}
+	return summary
+}

--- a/sdk/e2e/account_management_dkvs_e2e_test.go
+++ b/sdk/e2e/account_management_dkvs_e2e_test.go
@@ -1,0 +1,138 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sat20-labs/sat20wallet/sdk/account"
+	"github.com/sat20-labs/sat20wallet/sdk/wallet"
+	"github.com/sat20-labs/satoshinet/chaincfg"
+	contractcommon "github.com/sat20-labs/satoshinet/contract"
+	templateruntime "github.com/sat20-labs/satoshinet/contract/template"
+	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+	"github.com/sat20-labs/satoshinet/wire"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRealSatoshiNetAccountManagementAutopaySync(t *testing.T) {
+	defaults := dkvsindexer.NetworkDefaultsForParams(&chaincfg.TestNetParams)
+	fixture := newDKVSNoPluginTemplateFixtureWithArgs(t,
+		map[string]int64{defaults.AutopayFeeAssetName: 20000}, nil, nil, dkvsMinerArgs(t))
+	waitForDKVSPeerReady(t, fixture.Network)
+
+	gas := contractcommon.GetGasAssetName()
+	owner := newDKVSKeyPathActor(t, keyFromMnemonic(t, dkvsClientMnemonic, 0))
+	require.Equal(t, defaults.AutopayDeployer, owner.Address)
+	gasOuts := splitToDKVSKeyPathActors(t, fixture, fixture.gasAnchor, gas,
+		[]int64{300000, 300000}, []int64{10000, 10000}, []*dkvsKeyPathActor{owner, owner})
+	feeOuts := splitToDKVSKeyPathActors(t, fixture, fixture.assetAnchors[defaults.AutopayFeeAssetName],
+		defaults.AutopayFeeAssetName, []int64{5000}, []int64{10000}, []*dkvsKeyPathActor{owner})
+
+	content, err := defaults.AutopayContent()
+	require.NoError(t, err)
+	deployAssets := txAsset(gas, 290000)
+	deployAssets = append(deployAssets, txAsset(defaults.AutopayFeeAssetName, 5000)...)
+	deploy, contractAddress := buildDKVSKeyPathTemplateDeploy(t, owner,
+		contractcommon.TemplateAutopay, content, owner.Address, defaults.AutopayDeployNonce,
+		[]dkvsPrevOut{gasOuts[0], feeOuts[0]}, wire.TxOut{Value: 10000, Assets: deployAssets})
+	fixture.Network.sendManyAndMine(t, []*wire.MsgTx{deploy}, 0)
+	heartbeat := buildDKVSKeyPathAssetTransfer(t, owner, gasOuts[1], gas, 290000, 9000, owner)
+	fixture.Network.sendManyAndMine(t, []*wire.MsgTx{heartbeat}, 0)
+	state := fetchTemplateAutopayView(t, fixture.Network.Bootstrap, contractAddress.MustEncode())
+	require.Equal(t, templateruntime.AutopayStatusActive, state.Status)
+
+	pubKey := owner.Wallet.GetPubKey().SerializeCompressed()
+	accountID := dkvsindexer.AccountID(pubKey)
+	prefix, err := dkvsindexer.AccountPersonalKey(accountID, "account/recovery")
+	require.NoError(t, err)
+	_, _, err = dkvsClientForNode(t, fixture.Network.Miner).SubscribePrefix(prefix)
+	require.NoError(t, err)
+	require.NoError(t, connectNode(fixture.Network.Miner, fixture.Network.Core))
+
+	guardianPrivate, guardianPublic, err := account.GenerateGuardianKey(nil)
+	require.NoError(t, err)
+	questions := []account.QuestionAnswer{
+		{Question: account.KnowledgeQuestion{ID: "book", Prompt: "指定版本书籍第十页最后十个字", IgnorePunctuation: true}, Answer: "月光落在安静的旧桥上", Confirmation: "月光落在安静的旧桥上"},
+		{Question: account.KnowledgeQuestion{ID: "note", Prompt: "私人纸条中的指定句子", IgnorePunctuation: true}, Answer: "yellow bicycle beside the winter river", Confirmation: "yellow bicycle beside the winter river"},
+		{Question: account.KnowledgeQuestion{ID: "family", Prompt: "未公开的家庭约定", IgnorePunctuation: true}, Answer: "周日傍晚六点在老树下见", Confirmation: "周日傍晚六点在老树下见"},
+	}
+	backup := account.Backup{Version: account.Version, Wallets: []account.WalletBackup{{
+		Name: "Primary", Mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		AccountCount: 2, SubAccounts: []account.SubAccount{{Index: 0, DID: "alice"}, {Index: 1, DID: "alice-work"}},
+	}}}
+	client := dkvsClientForNode(t, fixture.Network.Bootstrap)
+	autopay := wallet.DKVSAutopayOptions{AddressParams: &chaincfg.TestNetParams, PoolContract: contractAddress.MustEncode()}
+	recordOptions := dkvsindexer.RecordOptions{Seq: 1, TTL: 60000, ExpiryHeight: 1000}
+	repository, err := wallet.NewAccountDKVSRepository(client, owner.Wallet, autopay, recordOptions)
+	require.NoError(t, err)
+	manager := account.NewManager(repository)
+	pkg, err := manager.CreateRecoveryPackage(account.CreateOptions{AccountID: accountID, Backup: backup,
+		RecoveryMode: account.RecoveryMode2Of3, Questions: questions, GuardianMailboxID: accountID,
+		GuardianPublicKey: guardianPublic})
+	require.NoError(t, err)
+	require.NoError(t, manager.Publish(context.Background(), *pkg))
+	require.NoError(t, client.PutAccountGuardianCapsuleWithAutopay(owner.Wallet, accountID,
+		*pkg.GuardianCapsule, recordOptions, autopay))
+
+	values := map[string][]byte{}
+	for name, value := range map[string]interface{}{
+		"envelope": pkg.Envelope, "share/dkvs": pkg.DKVSShareCapsule,
+		"questions": pkg.KnowledgeBundle, "manifest": pkg.Manifest,
+	} {
+		encoded, encodeErr := json.Marshal(value)
+		require.NoError(t, encodeErr)
+		key, keyErr := dkvsindexer.PersonalKey(pubKey,
+			"account/recovery/"+pkg.Envelope.Locator.PackageID+"/"+name)
+		require.NoError(t, keyErr)
+		values[key] = encoded
+	}
+	guardianBytes, err := json.Marshal(pkg.GuardianCapsule)
+	require.NoError(t, err)
+	guardianKey, err := dkvsindexer.MailShareKey(accountID, pkg.GuardianCapsule.PackageID, pkg.GuardianCapsule.ShareID)
+	require.NoError(t, err)
+	values[guardianKey] = guardianBytes
+	for key, value := range values {
+		requireDKVSValue(t, fixture.Network.Bootstrap, key, value)
+		requireDKVSValue(t, fixture.Network.Core, key, value)
+		requireDKVSValue(t, fixture.Network.Miner, key, value)
+	}
+
+	coreClient := dkvsClientForNode(t, fixture.Network.Core)
+	readRepository, err := wallet.NewReadOnlyAccountDKVSRepository(coreClient, accountID)
+	require.NoError(t, err)
+	loaded, err := account.NewManager(readRepository).Load(context.Background(), pkg.Envelope.Locator)
+	require.NoError(t, err)
+	guardianRecord, err := coreClient.GetMailboxShare(accountID, pkg.GuardianCapsule.PackageID, pkg.GuardianCapsule.ShareID)
+	require.NoError(t, err)
+	var storedGuardian account.GuardianShareCapsule
+	require.NoError(t, json.Unmarshal(guardianRecord.Value, &storedGuardian))
+	guardianShare, err := account.DecryptGuardianShare(storedGuardian, guardianPrivate)
+	require.NoError(t, err)
+	dkvsShare, err := account.RecoverDKVSShare(loaded.DKVSShareCapsule, loaded.KnowledgeBundle,
+		[]account.AnswerAttempt{{QuestionID: "book", Answer: "月光落在安静的旧桥上。"},
+			{QuestionID: "note", Answer: "yellow bicycle beside the winter river"}})
+	require.NoError(t, err)
+	restored, secret, err := account.RecoverAccount(loaded.Envelope, dkvsShare, guardianShare)
+	require.NoError(t, err)
+	for index := range secret {
+		secret[index] = 0
+	}
+	require.Equal(t, backup.Wallets[0].Name, restored.Wallets[0].Name)
+	require.Equal(t, uint32(2), restored.Wallets[0].AccountCount)
+
+	packagePrefix, err := dkvsindexer.AccountPersonalKey(accountID,
+		"account/recovery/"+pkg.Envelope.Locator.PackageID)
+	require.NoError(t, err)
+	records, total, err := coreClient.ListRecords(packagePrefix, 0, 10)
+	require.NoError(t, err)
+	require.Equal(t, 4, total)
+	require.Len(t, records, 4)
+	usage, err := coreClient.GetUsage(packagePrefix)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, uint64(4), usage.ActiveRecords)
+	require.Greater(t, usage.ActiveTotalSize, uint64(0))
+	require.True(t, strings.HasPrefix(pkg.Manifest.Locator.AccountID, accountID))
+}

--- a/sdk/e2e/dkvs_noplugin_harness_test.go
+++ b/sdk/e2e/dkvs_noplugin_harness_test.go
@@ -1,0 +1,228 @@
+package e2e
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	indexercommon "github.com/sat20-labs/indexer/common"
+	contractcommon "github.com/sat20-labs/satoshinet/contract"
+	"github.com/sat20-labs/satoshinet/wire"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dkvsNoPluginBuildMu       sync.Mutex
+	dkvsNoPluginTestArtifacts satoshinetArtifacts
+)
+
+// dkvsNoPluginBuildArtifacts builds public test binaries that do not depend on
+// the private Transcend STP plugin. DKVS and template AUTOPAY behavior are
+// provided by SatoshiNet itself; only the miner wallet plugin is required.
+func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
+	t.Helper()
+	dkvsNoPluginBuildMu.Lock()
+	defer dkvsNoPluginBuildMu.Unlock()
+	if dkvsNoPluginTestArtifacts.coreExecutable != "" {
+		return dkvsNoPluginTestArtifacts
+	}
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	workspace := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	satoshinetDir := filepath.Join(workspace, "satoshinet")
+	require.FileExists(t, filepath.Join(satoshinetDir, "go.mod"))
+	sdkPluginDir := filepath.Join(workspace, "sat20wallet", "sdk", "plugin")
+	require.FileExists(t, filepath.Join(sdkPluginDir, "main.go"))
+
+	outputDir := filepath.Join(os.TempDir(), "sat20wallet-satoshinet-dkvs-rpctest")
+	require.NoError(t, os.MkdirAll(outputDir, 0o755))
+
+	artifacts := satoshinetArtifacts{
+		coreExecutable:  filepath.Join(outputDir, "satoshinet-core-dkvs-rpctest"),
+		minerExecutable: filepath.Join(outputDir, "satoshinet-miner-dkvs-rpctest"),
+		minerPlugin:     filepath.Join(outputDir, "wallet.so"),
+	}
+	if runtime.GOOS == "windows" {
+		artifacts.coreExecutable += ".exe"
+		artifacts.minerExecutable += ".exe"
+	}
+
+	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", artifacts.minerPlugin, "main.go")
+	cmd.Dir = sdkPluginDir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	cmd = exec.Command("go", "build", "-tags=rpctest,wallet_plugin", "-o", artifacts.minerExecutable,
+		"github.com/sat20-labs/satoshinet")
+	cmd.Dir = satoshinetDir
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	cmd = exec.Command("go", "build", "-tags=rpctest", "-o", artifacts.coreExecutable,
+		"github.com/sat20-labs/satoshinet")
+	cmd.Dir = satoshinetDir
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	dkvsNoPluginTestArtifacts = artifacts
+	return dkvsNoPluginTestArtifacts
+}
+
+func stageDKVSNoPluginNodeRuntime(t *testing.T, role, mnemonic, l1IndexerHost, l2IndexerHost, rpcHost,
+	managementHost, nodeDir string) string {
+	t.Helper()
+	artifacts := dkvsNoPluginBuildArtifacts(t)
+	executable := artifacts.coreExecutable
+	if role == "miner" {
+		executable = artifacts.minerExecutable
+		copySatoshiNetRuntimeFile(t, artifacts.minerPlugin, filepath.Join(nodeDir, "wallet.so"))
+	}
+
+	stagedExecutable := filepath.Join(nodeDir, filepath.Base(executable))
+	copySatoshiNetRuntimeFile(t, executable, stagedExecutable)
+	require.NoError(t, os.WriteFile(filepath.Join(nodeDir, "conf.yaml"), []byte(fmt.Sprintf(satoshinetTestConf,
+		l1IndexerHost, l2IndexerHost, rpcHost, managementHost, mnemonic)), 0o600))
+	return stagedExecutable
+}
+
+func startDKVSNoPluginNodeWithArgs(t *testing.T, fakeL1 *fakeL1Indexer, role, mnemonic string,
+	extraArgs []string) *testHarness {
+	t.Helper()
+
+	nodeKey := keyFromMnemonic(t, mnemonic, 0)
+	nodePubKey := hex.EncodeToString(nodeKey.PubKey().SerializeCompressed())
+	p2pAddr, rpcAddr, managementAddr := nextNodeAddresses(t)
+	nodeDir := t.TempDir()
+	dataDir := filepath.Join(nodeDir, "data")
+	logDir := filepath.Join(nodeDir, "logs")
+	args := []string{
+		"--notls",
+		"--nocheckpoints",
+		"--nodnsseed",
+		"--testnet",
+		"--listen=" + p2pAddr,
+		"--rpclisten=" + rpcAddr,
+		"--rpcuser=user",
+		"--rpcpass=pass",
+		"--datadir=" + dataDir,
+		"--logdir=" + logDir,
+		"--indexerscheme=http",
+		"--indexerhost=" + fakeL1.host(),
+		"--indexerproxy=testnet",
+	}
+	if role != "miner" {
+		args = append(args, "--generate", "--miningpubkey="+nodePubKey)
+	}
+	args = append(args, extraArgs...)
+	env := []string{
+		"SATOSHINET_RPCTEST_NODE_ROLE=" + role,
+		"SATOSHINET_RPCTEST_STP_MNEMONIC=" + mnemonic,
+		"SATOSHINET_RPCTEST_STP_PASSWORD=rpctest",
+	}
+	for _, name := range []string{
+		"SATOSHINET_POS_MINER_INTERVAL",
+		"SATOSHINET_POS_PREWARNING_INTERVAL",
+		"SATOSHINET_POS_CHECKING_INTERVAL",
+	} {
+		if value := os.Getenv(name); value != "" {
+			env = append(env, name+"="+value)
+		}
+	}
+
+	harness := newTestHarness(t, stageDKVSNoPluginNodeRuntime(t, role, mnemonic, fakeL1.host(),
+		l2IndexerHost(t, rpcAddr), rpcAddr, managementAddr, nodeDir), nodeDir, p2pAddr, rpcAddr, args, env)
+	t.Logf("started public DKVS %s node: pid=%d rpc=%s p2p=%s log=%s", role, harness.NodePID(),
+		harness.RPCAddress(), harness.P2PAddress(), harness.LogFile())
+	return harness
+}
+
+func newDKVSNoPluginNetworkWithArgs(t *testing.T, fakeL1 *fakeL1Indexer, bootstrapArgs, coreArgs,
+	minerArgs []string) *realSatoshiNet {
+	t.Helper()
+	configureFastPOSTimers(t)
+
+	bootstrap := startDKVSNoPluginNodeWithArgs(t, fakeL1, "bootstrap", bootstrapMnemonic, bootstrapArgs)
+	core := startDKVSNoPluginNodeWithArgs(t, fakeL1, "core", coreMnemonic, coreArgs)
+	miner := startDKVSNoPluginNodeWithArgs(t, fakeL1, "miner", minerMnemonic, minerArgs)
+
+	require.NoError(t, connectNode(core, bootstrap))
+	require.NoError(t, connectNode(miner, bootstrap))
+	nodes := []*testHarness{bootstrap, core, miner}
+	require.NoError(t, joinBlocks(nodes))
+	return &realSatoshiNet{Bootstrap: bootstrap, Core: core, Miner: miner, Nodes: nodes, fakeL1: fakeL1}
+}
+
+func newDKVSNoPluginTemplateFixtureWithArgs(t *testing.T, assets map[string]int64, bootstrapArgs,
+	coreArgs, minerArgs []string) *templateFixture {
+	t.Helper()
+	profiles := make([]templateAssetProfile, 0, len(assets))
+	for _, asset := range sortedAssetNames(assets) {
+		profiles = append(profiles, templateAssetProfile{Name: asset, Asset: asset, Precision: 0,
+			Supply: fmt.Sprintf("%d", assets[asset])})
+	}
+	return newDKVSNoPluginTemplateFixtureWithProfilesAndArgs(t, profiles, bootstrapArgs, coreArgs, minerArgs)
+}
+
+func newDKVSNoPluginTemplateFixtureWithProfilesAndArgs(t *testing.T, profiles []templateAssetProfile,
+	bootstrapArgs, coreArgs, minerArgs []string) *templateFixture {
+	t.Helper()
+	oldEnableTesting := indexercommon.ENABLE_TESTING
+	indexercommon.ENABLE_TESTING = true
+	t.Cleanup(func() { indexercommon.ENABLE_TESTING = oldEnableTesting })
+
+	const lockedValue = int64(20_000_000)
+	gas := contractcommon.GetGasAssetName()
+	bootstrapKey := keyFromMnemonic(t, bootstrapMnemonic, 0)
+	coreKey := keyFromMnemonic(t, coreMnemonic, 0)
+	actorA := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 1))
+	actorB := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 2))
+	actorC := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 3))
+	actorD := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 4))
+	actorE := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 5))
+	actorF := newTemplateActor(t, keyFromMnemonic(t, bootstrapMnemonic, 6))
+
+	witnessScript, lockedPkScript, err := getP2WSHScript(bootstrapKey.PubKey().SerializeCompressed(),
+		coreKey.PubKey().SerializeCompressed())
+	require.NoError(t, err)
+
+	l1Assets := []fakeL1Asset{{
+		Utxo: templateLockedOutPoint("gas", 0), Value: lockedValue,
+		Assets: map[string]string{gas: "100000000"},
+	}}
+	profileMap := make(map[string]templateAssetProfile, len(profiles))
+	for i, profile := range sortedProfiles(profiles) {
+		profileMap[profile.Asset] = profile
+		l1Assets = append(l1Assets, fakeL1Asset{
+			Utxo: templateLockedOutPoint(profile.Asset, i+1), Value: lockedValue,
+			Assets: map[string]string{profile.Asset: profile.Supply},
+			Metadata: map[string]fakeL1AssetMeta{profile.Asset: {
+				Precision: profile.Precision, BindingSat: profile.BindingSat,
+			}},
+		})
+	}
+	fakeL1 := newFakeL1Indexer(t, hex.EncodeToString(bootstrapKey.PubKey().SerializeCompressed()),
+		lockedPkScript, l1Assets)
+	network := newDKVSNoPluginNetworkWithArgs(t, fakeL1, bootstrapArgs, coreArgs, minerArgs)
+
+	gasAnchor := buildAnchorTx(t, templateLockedOutPoint("gas", 0), lockedValue,
+		txAsset(gas, 100000000), gas+"-100000000-0-0", witnessScript, bootstrapKey, actorA.PkScript)
+	network.sendAndMine(t, gasAnchor, 1)
+
+	assetAnchors := make(map[string]*wire.MsgTx)
+	for i, profile := range sortedProfiles(profiles) {
+		anchor := buildAnchorTx(t, templateLockedOutPoint(profile.Asset, i+1), lockedValue,
+			txAssetProfile(t, profile, profile.Supply), fmt.Sprintf("%s-%s-%d-%d", profile.Asset,
+				profile.Supply, profile.Precision, profile.BindingSat), witnessScript, bootstrapKey, actorA.PkScript)
+		network.sendAndMine(t, anchor, 1)
+		assetAnchors[profile.Asset] = anchor
+	}
+
+	return &templateFixture{Network: network, A: actorA, B: actorB, C: actorC, D: actorD, E: actorE,
+		F: actorF, gasAnchor: gasAnchor, assetAnchors: assetAnchors, profiles: profileMap}
+}

--- a/sdk/e2e/testdata/satoshinet-rpctest-hardening.patch
+++ b/sdk/e2e/testdata/satoshinet-rpctest-hardening.patch
@@ -1,0 +1,43 @@
+diff --git a/ossec/harden.go b/ossec/harden.go
+index 037bb77..db22e63 100644
+--- a/ossec/harden.go
++++ b/ossec/harden.go
+@@ -41,6 +41,10 @@ func prctl(option, arg2, arg3, arg4, arg5 uintptr) error {
+ }
+ 
+ func Init() error {
++	if skipProcessHardening {
++		return nil
++	}
++
+ 	if runtime.GOOS != "linux" {
+ 		return nil
+ 	}
+diff --git a/ossec/production_flag.go b/ossec/production_flag.go
+new file mode 100644
+index 0000000..f486d76
+--- /dev/null
++++ b/ossec/production_flag.go
+@@ -0,0 +1,7 @@
++//go:build !rpctest
++
++package ossec
++
++// Production builds keep all process-hardening checks enabled.
++const skipProcessHardening = false
++
+diff --git a/ossec/rpctest_flag.go b/ossec/rpctest_flag.go
+new file mode 100644
+index 0000000..aab2431
+--- /dev/null
++++ b/ossec/rpctest_flag.go
+@@ -0,0 +1,9 @@
++//go:build rpctest
++
++package ossec
++
++// Hosted CI workers cannot grant the unlimited RLIMIT_MEMLOCK required by
++// mlockall. This compile-time test-only switch allows rpctest binaries to run;
++// production builds continue to execute the full hardening path.
++const skipProcessHardening = true
++

--- a/sdk/wallet/account_guardian.go
+++ b/sdk/wallet/account_guardian.go
@@ -1,0 +1,32 @@
+package wallet
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sat20-labs/sat20wallet/sdk/account"
+	"github.com/sat20-labs/sat20wallet/sdk/common"
+	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+)
+
+func (p *SatsNetDKVSClient) PutAccountGuardianCapsuleWithAutopay(owner common.Wallet, mailboxID string, capsule account.GuardianShareCapsule, options dkvsindexer.RecordOptions, autopay DKVSAutopayOptions) error {
+	if owner == nil {
+		return fmt.Errorf("guardian mailbox owner wallet is required")
+	}
+	encoded, err := json.Marshal(capsule)
+	if err != nil {
+		return err
+	}
+	if len(encoded) > account.MaxRecoveryObjectSize {
+		return fmt.Errorf("guardian capsule exceeds DKVS value limit")
+	}
+	record, err := NewDKVSMailShareRecord(owner, mailboxID, capsule.PackageID, capsule.ShareID, encoded, options)
+	if err != nil {
+		return err
+	}
+	if err := attachDKVSAutopayFeeProof(owner, record, autopay); err != nil {
+		return err
+	}
+	_, err = p.PutMailboxShare(record)
+	return err
+}

--- a/sdk/wallet/account_guardian.go
+++ b/sdk/wallet/account_guardian.go
@@ -20,7 +20,11 @@ func (p *SatsNetDKVSClient) PutAccountGuardianCapsuleWithAutopay(owner common.Wa
 	if len(encoded) > account.MaxRecoveryObjectSize {
 		return fmt.Errorf("guardian capsule exceeds DKVS value limit")
 	}
-	record, err := NewDKVSMailShareRecord(owner, mailboxID, capsule.PackageID, capsule.ShareID, encoded, options)
+	key, err := dkvsindexer.MailShareKey(mailboxID, capsule.PackageID, capsule.ShareID)
+	if err != nil {
+		return err
+	}
+	record, err := NewDKVSSignedRecord(owner, key, encoded, options)
 	if err != nil {
 		return err
 	}

--- a/sdk/wallet/account_repository.go
+++ b/sdk/wallet/account_repository.go
@@ -1,0 +1,225 @@
+package wallet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/sat20-labs/sat20wallet/sdk/account"
+	"github.com/sat20-labs/sat20wallet/sdk/common"
+	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+)
+
+const accountRecoveryPath = "account/recovery"
+
+type AccountDKVSRepository struct {
+	client        *SatsNetDKVSClient
+	owner         common.Wallet
+	autopay       DKVSAutopayOptions
+	recordOptions dkvsindexer.RecordOptions
+	accountID     string
+}
+
+func NewAccountDKVSRepository(client *SatsNetDKVSClient, owner common.Wallet, autopay DKVSAutopayOptions, options dkvsindexer.RecordOptions) (*AccountDKVSRepository, error) {
+	if client == nil || owner == nil {
+		return nil, fmt.Errorf("DKVS client and owner wallet are required")
+	}
+	accountID := dkvsindexer.AccountID(owner.GetPubKey().SerializeCompressed())
+	if accountID == "" {
+		return nil, fmt.Errorf("invalid account owner public key")
+	}
+	return &AccountDKVSRepository{client: client, owner: owner, autopay: autopay, recordOptions: options, accountID: accountID}, nil
+}
+
+func NewReadOnlyAccountDKVSRepository(client *SatsNetDKVSClient, accountID string) (*AccountDKVSRepository, error) {
+	if client == nil {
+		return nil, fmt.Errorf("DKVS client is required")
+	}
+	if _, err := dkvsindexer.AccountPubKey(accountID); err != nil {
+		return nil, err
+	}
+	return &AccountDKVSRepository{client: client, accountID: accountID}, nil
+}
+
+func (r *AccountDKVSRepository) AccountID() string { return r.accountID }
+func accountPath(packageID, name string) string     { return accountRecoveryPath + "/" + packageID + "/" + name }
+
+func (r *AccountDKVSRepository) putJSON(path string, value any) error {
+	if r.owner == nil {
+		return fmt.Errorf("read-only account repository")
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	if len(encoded) > account.MaxRecoveryObjectSize {
+		return fmt.Errorf("account recovery object exceeds DKVS value limit")
+	}
+	_, err = r.client.PutPersonalRecordWithAutopay(r.owner, path, encoded, r.recordOptions, r.autopay)
+	return err
+}
+
+func (r *AccountDKVSRepository) getJSON(path string, target any) error {
+	pubKey, err := dkvsindexer.AccountPubKey(r.accountID)
+	if err != nil {
+		return err
+	}
+	key, err := dkvsindexer.PersonalKey(pubKey, path)
+	if err != nil {
+		return err
+	}
+	record, err := r.client.GetVerifiedRecord(key, dkvsindexer.RecordVerificationOptions{ExpectedKey: key})
+	if err != nil {
+		return err
+	}
+	if record == nil || len(record.Value) == 0 || len(record.Value) > account.MaxRecoveryObjectSize {
+		return fmt.Errorf("invalid account recovery object")
+	}
+	return json.Unmarshal(record.Value, target)
+}
+
+func (r *AccountDKVSRepository) assertLocator(locator account.Locator) error {
+	if err := account.ValidateLocator(locator); err != nil {
+		return err
+	}
+	if locator.AccountID != r.accountID {
+		return fmt.Errorf("locator does not belong to repository account")
+	}
+	return nil
+}
+
+func (r *AccountDKVSRepository) SaveEnvelope(_ context.Context, value account.Envelope) error {
+	if err := r.assertLocator(value.Locator); err != nil {
+		return err
+	}
+	return r.putJSON(accountPath(value.Locator.PackageID, "envelope"), value)
+}
+func (r *AccountDKVSRepository) SaveDKVSShareCapsule(_ context.Context, locator account.Locator, value account.DKVSShareCapsule) error {
+	if err := r.assertLocator(locator); err != nil {
+		return err
+	}
+	return r.putJSON(accountPath(locator.PackageID, "share/dkvs"), value)
+}
+func (r *AccountDKVSRepository) SaveKnowledgeBundle(_ context.Context, locator account.Locator, value account.KnowledgeRecoveryBundle) error {
+	if err := r.assertLocator(locator); err != nil {
+		return err
+	}
+	return r.putJSON(accountPath(locator.PackageID, "questions"), value)
+}
+func (r *AccountDKVSRepository) SaveManifest(_ context.Context, value account.Manifest) error {
+	if err := r.assertLocator(value.Locator); err != nil {
+		return err
+	}
+	return r.putJSON(accountPath(value.Locator.PackageID, "manifest"), value)
+}
+func (r *AccountDKVSRepository) LoadEnvelope(_ context.Context, locator account.Locator) (*account.Envelope, error) {
+	if err := r.assertLocator(locator); err != nil {
+		return nil, err
+	}
+	var value account.Envelope
+	if err := r.getJSON(accountPath(locator.PackageID, "envelope"), &value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+func (r *AccountDKVSRepository) LoadDKVSShareCapsule(_ context.Context, locator account.Locator) (*account.DKVSShareCapsule, error) {
+	if err := r.assertLocator(locator); err != nil {
+		return nil, err
+	}
+	var value account.DKVSShareCapsule
+	if err := r.getJSON(accountPath(locator.PackageID, "share/dkvs"), &value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+func (r *AccountDKVSRepository) LoadKnowledgeBundle(_ context.Context, locator account.Locator) (*account.KnowledgeRecoveryBundle, error) {
+	if err := r.assertLocator(locator); err != nil {
+		return nil, err
+	}
+	var value account.KnowledgeRecoveryBundle
+	if err := r.getJSON(accountPath(locator.PackageID, "questions"), &value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+func (r *AccountDKVSRepository) LoadManifest(_ context.Context, locator account.Locator) (*account.Manifest, error) {
+	if err := r.assertLocator(locator); err != nil {
+		return nil, err
+	}
+	var value account.Manifest
+	if err := r.getJSON(accountPath(locator.PackageID, "manifest"), &value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+type AccountWalletMetadata struct {
+	Name            string
+	SubAccountDIDs  map[uint32]string
+}
+
+func (p *Manager) ExportAccountBackup(password string, metadata map[int64]AccountWalletMetadata) (account.Backup, error) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	ids := make([]int64, 0, len(p.walletInfoMap))
+	for id := range p.walletInfoMap {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	backup := account.Backup{Version: account.Version, Wallets: make([]account.WalletBackup, 0, len(ids))}
+	for _, id := range ids {
+		info := p.walletInfoMap[id]
+		if info == nil || info.Type != WALLET_TYPE_MNEMONIC {
+			return account.Backup{}, fmt.Errorf("wallet %d is not a mnemonic wallet", id)
+		}
+		mnemonic, err := p.loadWalletSecret(info, password)
+		if err != nil {
+			return account.Backup{}, err
+		}
+		meta := metadata[id]
+		name := meta.Name
+		if name == "" {
+			name = fmt.Sprintf("Wallet %d", len(backup.Wallets)+1)
+		}
+		subAccounts := make([]account.SubAccount, info.Accounts)
+		for index := 0; index < info.Accounts; index++ {
+			did := meta.SubAccountDIDs[uint32(index)]
+			if did == "" {
+				return account.Backup{}, fmt.Errorf("wallet %d sub-account %d is missing an Ordinals DID name", id, index)
+			}
+			subAccounts[index] = account.SubAccount{Index: uint32(index), DID: did}
+		}
+		backup.Wallets = append(backup.Wallets, account.WalletBackup{Name: name, Mnemonic: mnemonic, AccountCount: uint32(info.Accounts), SubAccounts: subAccounts})
+	}
+	return account.NormalizeBackup(backup)
+}
+
+func (p *Manager) RestoreAccountBackup(value account.Backup, password string) error {
+	backup, err := account.NormalizeBackup(value)
+	if err != nil {
+		return err
+	}
+	if p.IsWalletExist() {
+		return fmt.Errorf("account restore requires an empty wallet database")
+	}
+	for _, item := range backup.Wallets {
+		id, err := p.ImportWallet(item.Mnemonic, password)
+		if err != nil {
+			return err
+		}
+		p.mutex.Lock()
+		info := p.walletInfoMap[id]
+		if info == nil {
+			p.mutex.Unlock()
+			return fmt.Errorf("restored wallet %d was not persisted", id)
+		}
+		info.Accounts = int(item.AccountCount)
+		err = saveWallet(p.db, &info.WalletInDB)
+		p.mutex.Unlock()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sdk/wallet/account_repository.go
+++ b/sdk/wallet/account_repository.go
@@ -43,7 +43,9 @@ func NewReadOnlyAccountDKVSRepository(client *SatsNetDKVSClient, accountID strin
 }
 
 func (r *AccountDKVSRepository) AccountID() string { return r.accountID }
-func accountPath(packageID, name string) string     { return accountRecoveryPath + "/" + packageID + "/" + name }
+func accountPath(packageID, name string) string {
+	return accountRecoveryPath + "/" + packageID + "/" + name
+}
 
 func (r *AccountDKVSRepository) putJSON(path string, value any) error {
 	if r.owner == nil {
@@ -155,8 +157,8 @@ func (r *AccountDKVSRepository) LoadManifest(_ context.Context, locator account.
 }
 
 type AccountWalletMetadata struct {
-	Name            string
-	SubAccountDIDs  map[uint32]string
+	Name           string
+	SubAccountDIDs map[uint32]string
 }
 
 func (p *Manager) ExportAccountBackup(password string, metadata map[int64]AccountWalletMetadata) (account.Backup, error) {


### PR DESCRIPTION
## Summary

Consolidates the self-custodial account-management work into one Go-centric implementation in `sat20wallet`, with the PWA/native platform boundary in the same PR.

This PR supersedes:

- `sat20-labs/wallet-sdk#1` — TypeScript account-management prototype
- `sat20-labs/sat20wallet#3` — standalone AUTOPAY E2E
- `sat20-labs/sat20wallet#4` — standalone secure-storage design
- `sat20-labs/satoshinet#11` — hosted-CI-only rpctest hardening bypass

The SatoshiNet test adjustment is applied locally by this PR's E2E workflow to an `rpctest` checkout. Production SatoshiNet code is unchanged and this PR has no cross-repository merge prerequisite.

## Go account core

Adds `sdk/account` with:

- focused multi-wallet backup: mnemonic, wallet name, sub-account count/index and Ordinals DID name;
- random 32-byte `AccountSecret` and AES-256-GCM account envelope;
- package-bound Shamir 2-of-2 and 2-of-3 shares over GF(2^8), using CSPRNG coefficients;
- convenience 2-of-3 recovery and enhanced-security 2-of-2 recovery;
- X25519 + AES-256-GCM Guardian share capsules;
- account recovery and new-device recovery-rehearsal APIs.

## Fuzzy private-knowledge recovery

Adds a pure-Go translation of the Decentralized Identity Foundation `fuzzy-encryption` construction:

- finite prime field;
- polynomial secure sketch;
- Berlekamp-Welch error recovery;
- scrypt set commitment/extractor;
- HMAC-SHA3-512 deterministic key derivation;
- CSPRNG, zero-factor rejection, bounded decoder, reference vector and fuzz coverage.

Three independent private-knowledge questions protect a second-level 2-of-3 Shamir split of `K_dkvs`. Any two correct questions recover `K_dkvs`, which decrypts the actual DKVS account share. A single question cannot recover that share.

The previous SimHash/`float64`/chaff PoC is not used in the cryptographic recovery path.

## DKVS and AUTOPAY integration

Adds Go wallet adapters that:

- write package-versioned data under `/personal/<account_id>/account/recovery/<package_id>/...`;
- sign and pay with the same owner wallet through AUTOPAY;
- write envelope, DKVS-share capsule and knowledge bundle before the manifest commit marker;
- verify records when loading from DKVS;
- store encrypted Guardian shares under `/mail/<mailbox_id>/share/<package_id>/<share_id>`;
- export/import the existing multi-wallet Go `wallet.Manager` data model.

## PWA/native secure-storage boundary

Adds `SecureAccountStorage` and design guidance for:

- Android Keystore + BiometricPrompt/device credential;
- iOS Keychain/SecAccessControl and optional Secure Enclave wrapping;
- WebAuthn PRF on supported desktop/mobile browsers;
- Argon2id-wrapped device-key fallback;
- IndexedDB ciphertext/key-slot metadata only.

Adding a device deliberately executes the complete account-recovery flow and therefore acts as a real recovery rehearsal.

## Validation

The consolidated GitHub Actions workflow passed on the final head:

1. Go formatting checks;
2. `go test ./account/... -count=1`;
3. wallet integration compilation;
4. PWA dependency installation and TypeScript compilation;
5. a real bootstrap/core/miner SatoshiNet AUTOPAY E2E.

The E2E validates:

- AUTOPAY deployment and activation;
- creation of a real encrypted account recovery package;
- owner-signed `/personal` records and manifest-last publication;
- propagation to bootstrap, core and miner nodes;
- prefix listing and usage accounting;
- encrypted Guardian mailbox share storage;
- readback from another node;
- recovery of the DKVS share from two private-knowledge answers;
- Guardian share decryption;
- complete account backup recovery.

Additional local verification repeated the Go account tests, wallet compile, PWA TypeScript compile and full three-node E2E against the final branch.

## Review focus

1. Account backup scope and compatibility with the current multi-wallet/unified-derivation model.
2. Pure-Go Shamir share format and recovery profiles.
3. DIF fuzzy-recovery translation and question feature extraction.
4. DKVS owner/AUTOPAY repository boundary and manifest-last commit protocol.
5. Guardian mailbox ownership and encrypted share format.
6. PWA/native secure-storage interface; concrete platform adapters remain a PWA implementation task behind this reviewed boundary.

The PR is intentionally left unmerged for maintainer review.