### PR TITLE
fix: complete account-management post-merge validation

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -2,7 +2,7 @@ name: Account management
 
 on:
   push:
-    branches: [feat/account-management-complete]
+    branches: [main]
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Compile wallet integration
         working-directory: sat20wallet/sdk
         run: go test ./wallet -run '^$' -count=1
+      - name: Compile account E2E
+        working-directory: sat20wallet/sdk
+        run: go test ./e2e -run '^$' -count=1
 
   pwa-secure-storage:
     runs-on: ubuntu-latest
@@ -93,57 +96,3 @@ jobs:
       - name: Type-check PWA
         working-directory: pwa
         run: npm run compile
-
-  dkvs-autopay-e2e:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout wallet
-        uses: actions/checkout@v4
-        with:
-          path: sat20wallet
-          fetch-depth: 0
-      - name: Checkout indexer
-        uses: actions/checkout@v4
-        with:
-          repository: sat20-labs/indexer
-          path: indexer
-      - name: Checkout RGB11 engine
-        uses: actions/checkout@v4
-        with:
-          repository: sat20-labs/rgb11
-          path: rgb11
-      - name: Checkout SatoshiNet
-        uses: actions/checkout@v4
-        with:
-          repository: sat20-labs/satoshinet
-          path: satoshinet
-      - name: Checkout Transcend
-        uses: actions/checkout@v4
-        with:
-          repository: sat20-labs/transcend
-          path: transcend
-      - name: Apply rpctest-only SatoshiNet hardening patch
-        shell: bash
-        run: git -C satoshinet apply ../sat20wallet/sdk/e2e/testdata/satoshinet-rpctest-hardening.patch
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: sat20wallet/sdk/go.mod
-          cache: false
-      - name: Run account-management DKVS AUTOPAY e2e
-        working-directory: sat20wallet/sdk
-        shell: bash
-        run: |
-          set -o pipefail
-          go test ./e2e -run '^TestRealSatoshiNetAccountManagementAutopaySync$' -count=1 -v 2>&1 | tee /tmp/account-management-dkvs-e2e.log
-      - name: Upload e2e diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: account-management-dkvs-e2e-${{ github.run_id }}
-          path: |
-            /tmp/account-management-dkvs-e2e.log
-            /tmp/sat20wallet-satoshinet-rpctest-failures/**
-          if-no-files-found: warn
-          retention-days: 3

--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -118,6 +118,11 @@ jobs:
         with:
           repository: sat20-labs/satoshinet
           path: satoshinet
+      - name: Checkout Transcend
+        uses: actions/checkout@v4
+        with:
+          repository: sat20-labs/transcend
+          path: transcend
       - name: Apply rpctest-only SatoshiNet hardening patch
         shell: bash
         run: git -C satoshinet apply ../sat20wallet/sdk/e2e/testdata/satoshinet-rpctest-hardening.patch

--- a/pwa/lib/secure-account-storage.ts
+++ b/pwa/lib/secure-account-storage.ts
@@ -44,5 +44,5 @@ export class SecureAccountStorageUnavailableError extends Error {
 }
 
 export const assertSecureStorageAccountId = (accountId: string): void => {
-  if (!/^[0-9a-f]{64}$/.test(accountId)) throw new Error('accountId must be a lowercase SHA-256 hex string')
+  if (!/^[0-9a-f]{64}$/.test(accountId)) throw new Error('accountId must be a lowercase 32-byte x-only public key hex string')
 }

--- a/sdk/e2e/account_management_dkvs_e2e_test.go
+++ b/sdk/e2e/account_management_dkvs_e2e_test.go
@@ -47,7 +47,10 @@ func TestRealSatoshiNetAccountManagementAutopaySync(t *testing.T) {
 	accountID := dkvsindexer.AccountID(pubKey)
 	prefix, err := dkvsindexer.AccountPersonalKey(accountID, "account/recovery")
 	require.NoError(t, err)
-	_, _, err = dkvsClientForNode(t, fixture.Network.Miner).SubscribePrefix(prefix)
+	minerClient := dkvsClientForNode(t, fixture.Network.Miner)
+	_, _, err = minerClient.SubscribePrefix(prefix)
+	require.NoError(t, err)
+	_, _, err = minerClient.SubscribeMailbox(accountID)
 	require.NoError(t, err)
 	require.NoError(t, connectNode(fixture.Network.Miner, fixture.Network.Core))
 

--- a/sdk/e2e/dkvs_noplugin_harness_test.go
+++ b/sdk/e2e/dkvs_noplugin_harness_test.go
@@ -21,9 +21,9 @@ var (
 	dkvsNoPluginTestArtifacts satoshinetArtifacts
 )
 
-// dkvsNoPluginBuildArtifacts builds public test binaries that do not depend on
-// the private Transcend STP plugin. Generating bootstrap/core nodes require the
-// public wallet plugin for block signing, and the miner uses the same fixture.
+// dkvsNoPluginBuildArtifacts builds the DKVS test runtime in the same role
+// configuration as the production scripts: bootstrap/core use stp_plugin and
+// stpd.so, while the ordinary miner uses wallet_plugin and wallet.so.
 func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	t.Helper()
 	dkvsNoPluginBuildMu.Lock()
@@ -39,12 +39,15 @@ func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	require.FileExists(t, filepath.Join(satoshinetDir, "go.mod"))
 	sdkPluginDir := filepath.Join(workspace, "sat20wallet", "sdk", "plugin")
 	require.FileExists(t, filepath.Join(sdkPluginDir, "main.go"))
+	transcendPluginDir := filepath.Join(workspace, "transcend", "plugin")
+	require.FileExists(t, filepath.Join(transcendPluginDir, "main.go"))
 
 	outputDir := filepath.Join(os.TempDir(), "sat20wallet-satoshinet-dkvs-rpctest")
 	require.NoError(t, os.MkdirAll(outputDir, 0o755))
 
 	artifacts := satoshinetArtifacts{
 		coreExecutable:  filepath.Join(outputDir, "satoshinet-core-dkvs-rpctest"),
+		corePlugin:      filepath.Join(outputDir, "stpd.so"),
 		minerExecutable: filepath.Join(outputDir, "satoshinet-miner-dkvs-rpctest"),
 		minerPlugin:     filepath.Join(outputDir, "wallet.so"),
 	}
@@ -64,7 +67,12 @@ func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	output, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	cmd = exec.Command("go", "build", "-tags=rpctest,wallet_plugin", "-o", artifacts.coreExecutable,
+	cmd = exec.Command("go", "build", "-buildmode=plugin", "-o", artifacts.corePlugin, "main.go")
+	cmd.Dir = transcendPluginDir
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	cmd = exec.Command("go", "build", "-tags=rpctest,stp_plugin", "-o", artifacts.coreExecutable,
 		"github.com/sat20-labs/satoshinet")
 	cmd.Dir = satoshinetDir
 	output, err = cmd.CombinedOutput()
@@ -79,13 +87,17 @@ func stageDKVSNoPluginNodeRuntime(t *testing.T, role, mnemonic, l1IndexerHost, l
 	t.Helper()
 	artifacts := dkvsNoPluginBuildArtifacts(t)
 	executable := artifacts.coreExecutable
+	plugin := artifacts.corePlugin
+	pluginName := "stpd.so"
 	if role == "miner" {
 		executable = artifacts.minerExecutable
+		plugin = artifacts.minerPlugin
+		pluginName = "wallet.so"
 	}
-	copySatoshiNetRuntimeFile(t, artifacts.minerPlugin, filepath.Join(nodeDir, "wallet.so"))
 
 	stagedExecutable := filepath.Join(nodeDir, filepath.Base(executable))
 	copySatoshiNetRuntimeFile(t, executable, stagedExecutable)
+	copySatoshiNetRuntimeFile(t, plugin, filepath.Join(nodeDir, pluginName))
 	require.NoError(t, os.WriteFile(filepath.Join(nodeDir, "conf.yaml"), []byte(fmt.Sprintf(satoshinetTestConf,
 		l1IndexerHost, l2IndexerHost, rpcHost, managementHost, mnemonic)), 0o600))
 	return stagedExecutable

--- a/sdk/e2e/dkvs_noplugin_harness_test.go
+++ b/sdk/e2e/dkvs_noplugin_harness_test.go
@@ -22,8 +22,8 @@ var (
 )
 
 // dkvsNoPluginBuildArtifacts builds public test binaries that do not depend on
-// the private Transcend STP plugin. DKVS and template AUTOPAY behavior are
-// provided by SatoshiNet itself; only the miner wallet plugin is required.
+// the private Transcend STP plugin. Generating bootstrap/core nodes require the
+// public wallet plugin for block signing, and the miner uses the same fixture.
 func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	t.Helper()
 	dkvsNoPluginBuildMu.Lock()
@@ -64,7 +64,7 @@ func dkvsNoPluginBuildArtifacts(t *testing.T) satoshinetArtifacts {
 	output, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	cmd = exec.Command("go", "build", "-tags=rpctest", "-o", artifacts.coreExecutable,
+	cmd = exec.Command("go", "build", "-tags=rpctest,wallet_plugin", "-o", artifacts.coreExecutable,
 		"github.com/sat20-labs/satoshinet")
 	cmd.Dir = satoshinetDir
 	output, err = cmd.CombinedOutput()
@@ -81,8 +81,8 @@ func stageDKVSNoPluginNodeRuntime(t *testing.T, role, mnemonic, l1IndexerHost, l
 	executable := artifacts.coreExecutable
 	if role == "miner" {
 		executable = artifacts.minerExecutable
-		copySatoshiNetRuntimeFile(t, artifacts.minerPlugin, filepath.Join(nodeDir, "wallet.so"))
 	}
+	copySatoshiNetRuntimeFile(t, artifacts.minerPlugin, filepath.Join(nodeDir, "wallet.so"))
 
 	stagedExecutable := filepath.Join(nodeDir, filepath.Base(executable))
 	copySatoshiNetRuntimeFile(t, executable, stagedExecutable)

--- a/sdk/wallet/account_guardian.go
+++ b/sdk/wallet/account_guardian.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sat20-labs/sat20wallet/sdk/account"
 	"github.com/sat20-labs/sat20wallet/sdk/common"
 	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+	swire "github.com/sat20-labs/satoshinet/wire"
 )
 
 func (p *SatsNetDKVSClient) PutAccountGuardianCapsuleWithAutopay(owner common.Wallet, mailboxID string, capsule account.GuardianShareCapsule, options dkvsindexer.RecordOptions, autopay DKVSAutopayOptions) error {
@@ -33,4 +34,12 @@ func (p *SatsNetDKVSClient) PutAccountGuardianCapsuleWithAutopay(owner common.Wa
 	}
 	_, err = p.PutMailboxShare(record)
 	return err
+}
+
+func (p *SatsNetDKVSClient) GetMailboxShare(mailboxID, packageID, shareID string) (*swire.DKVSRecord, error) {
+	key, err := dkvsindexer.MailShareKey(mailboxID, packageID, shareID)
+	if err != nil {
+		return nil, err
+	}
+	return p.GetVerifiedRecord(key, dkvsindexer.RecordVerificationOptions{ExpectedKey: key})
 }


### PR DESCRIPTION
## Scope

This PR is limited to post-merge account-management validation fixes:

1. add `SatsNetDKVSClient.GetMailboxShare(...)` so the account recovery E2E can read the exact Guardian share record with client-side verification;
2. run the account-management workflow on pushes to `main` rather than the retired feature branch;
3. correct the PWA account ID validation message to describe the actual BIP340 x-only public-key identifier;
4. align the three-node E2E fixture with `satoshinet/build_core.sh`: bootstrap/core use `stp_plugin` plus `stpd.so`, while the ordinary miner uses `wallet_plugin` plus `wallet.so`;
5. subscribe the light miner to the Guardian mailbox before asserting mailbox-share synchronization, matching the existing DKVS mailbox E2E pattern.

No account model, cryptographic construction, DKVS policy, recovery flow, production SatoshiNet code, or platform storage design is changed.

## Validation

Public `sat20wallet` CI runs:

- Go formatting;
- account package tests;
- wallet integration compile;
- account E2E compile;
- PWA TypeScript compile.

The real bootstrap/core/miner DKVS AUTOPAY account-management E2E requires the private Transcend `stpd.so` source, so it was executed in a temporary private Transcend validation PR rather than introducing cross-repository credentials into this public repository. That E2E passed with the production role split and the temporary PR was closed without merge.

This PR is left unmerged for review.