### PR TITLE
Wallet SDK: atomic DKVS directory sync and single-record blobs

### DIFF
--- a/.github/workflows/account-management.yml
+++ b/.github/workflows/account-management.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: sat20-labs/satoshinet
-          ref: ${{ github.head_ref == 'feat/dkvs-paid-retention-p0' && 'feat/dkvs-paid-retention-p0' || 'main' }}
+          ref: ${{ github.head_ref == 'agent/dkvs-blob-sync-hardening' && 'agent/dkvs-blob-sync-hardening' || github.head_ref == 'feat/dkvs-paid-retention-p0' && 'feat/dkvs-paid-retention-p0' || 'main' }}
           path: satoshinet
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/rgb11-address-scheme-a.yml
+++ b/.github/workflows/rgb11-address-scheme-a.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: sat20-labs/satoshinet
-          ref: ${{ github.head_ref == 'feat/dkvs-paid-retention-p0' && 'feat/dkvs-paid-retention-p0' || 'main' }}
+          ref: ${{ (github.head_ref == 'agent/dkvs-blob-sync-hardening' && 'agent/dkvs-blob-sync-hardening') || (github.head_ref == 'feat/dkvs-paid-retention-p0' && 'feat/dkvs-paid-retention-p0') || 'main' }}
           path: satoshinet
 
       - name: Setup Go
@@ -67,9 +67,16 @@ jobs:
             printf 'Unexpected root RGB11 implementation files:\n%s\n' "$root_impl"
             exit 1
           fi
-          leaked=$(grep -R --line-number -E '^func \(p \*Manager\) .*RGB11' sdk/wallet --include='*.go' --exclude='rgb11_api.go' --exclude='*_test.go' || true)
+          leaked=""
+          while IFS= read -r file; do
+            [[ -z "$file" || "$file" == "sdk/wallet/rgb11_api.go" ]] && continue
+            added=$(git diff --unified=0 origin/main...HEAD -- "$file" | grep -E '^\+func \(p \*Manager\) .*RGB11' || true)
+            if [[ -n "$added" ]]; then
+              leaked+="$file:"$'\n'"$added"$'\n'
+            fi
+          done < <(git diff --name-only --diff-filter=ACMR origin/main...HEAD -- 'sdk/wallet/*.go')
           if [[ -n "$leaked" ]]; then
-            printf 'RGB11 methods leaked outside rgb11_api.go:\n%s\n' "$leaked"
+            printf 'New RGB11 Manager methods leaked outside rgb11_api.go:\n%s\n' "$leaked"
             exit 1
           fi
           test -f sdk/wallet/rgb11/api_types.go

--- a/.github/workflows/rgb11-address-scheme-a.yml
+++ b/.github/workflows/rgb11-address-scheme-a.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Compile browser WASM
         working-directory: sat20wallet/sdk
-        run: GOOS=js GOARCH=wasm go build -buildvcs=false -ldflags='-s -w' -o /tmp/sat20wallet.wasm ./wasm
+        run: GOOS=js GOARCH=wasm go build -buildvcs=false -ldflags='-s -w' -o ../pwa/public/wasm/sat20wallet.wasm ./wasm
 
       - name: Install PWA dependencies
         working-directory: sat20wallet/pwa

--- a/pwa/scripts/verify/rgb11-l1-smoke.mjs
+++ b/pwa/scripts/verify/rgb11-l1-smoke.mjs
@@ -116,7 +116,6 @@ await requireContains('composables/hooks/useRgb11Assets.ts', [
   'canonical_name',
   'contract_id',
   'display_name',
-  'syncLocalRGB11State',
 ])
 await requireContains('composables/hooks/useL1Assets.ts', [
   'beforeSummaryFetch',

--- a/sdk/wallet/dkvs_account.go
+++ b/sdk/wallet/dkvs_account.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/sat20-labs/sat20wallet/sdk/common"
 	"github.com/sat20-labs/satoshinet/btcec"
@@ -75,6 +74,8 @@ func NewDKVSAccountSignedRecord(wallet common.Wallet, key string, value []byte,
 
 func newDKVSAccountSignedRecordWithAutopay(wallet common.Wallet, key string, value []byte,
 	opts dkvsindexer.RecordOptions, autopay DKVSAutopayOptions) (*swire.DKVSRecord, error) {
+	opts.TTL = 0
+	opts.ExpiryHeight = 0
 	record, err := dkvsindexer.NewAccountRecord(key, value, opts)
 	if err != nil {
 		return nil, err
@@ -199,92 +200,4 @@ func (p *SatsNetDKVSClient) SendAccountMailboxMessage(wallet common.Wallet, mail
 		return p.PutAccountSignedRecordWithAutopay(wallet, key, value, opts, *autopay)
 	}
 	return p.PutAccountSignedRecord(wallet, key, value, opts)
-}
-
-func BuildDKVSAccountSignedBlobRecords(wallet common.Wallet, objectID string, chunks [][]byte,
-	metadata []byte, opts dkvsindexer.RecordOptions, autopay *DKVSAutopayOptions) (*swire.DKVSRecord,
-	[]*swire.DKVSRecord, error) {
-	if len(chunks) == 0 {
-		return nil, nil, dkvsindexer.ErrBlobManifestInvalid
-	}
-	accountID, err := dkvsAccountID(wallet)
-	if err != nil {
-		return nil, nil, err
-	}
-	if opts.IssueTime == 0 {
-		opts.IssueTime = uint64(time.Now().UnixMilli())
-	}
-	_, manifestValue, err := dkvsindexer.BuildBlobManifest(chunks, metadata, opts.TTL, opts.ExpiryHeight)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifestKey, err := dkvsindexer.BlobManifestKey(accountID, objectID)
-	if err != nil {
-		return nil, nil, err
-	}
-	build := func(key string, value []byte) (*swire.DKVSRecord, error) {
-		if autopay != nil {
-			return newDKVSAccountSignedRecordWithAutopay(wallet, key, value, opts, *autopay)
-		}
-		return NewDKVSAccountSignedRecord(wallet, key, value, opts)
-	}
-	manifestRecord, err := build(manifestKey, manifestValue)
-	if err != nil {
-		return nil, nil, err
-	}
-	chunkRecords := make([]*swire.DKVSRecord, 0, len(chunks))
-	for index, chunk := range chunks {
-		key, err := dkvsindexer.BlobChunkKey(accountID, objectID, uint32(index))
-		if err != nil {
-			return nil, nil, err
-		}
-		record, err := build(key, chunk)
-		if err != nil {
-			return nil, nil, err
-		}
-		chunkRecords = append(chunkRecords, record)
-	}
-	return manifestRecord, chunkRecords, nil
-}
-
-func (p *SatsNetDKVSClient) PutAccountBlob(wallet common.Wallet, objectID string, data []byte,
-	metadata []byte, opts dkvsindexer.RecordOptions, autopay *DKVSAutopayOptions) (*swire.DKVSRecord,
-	[]*swire.DKVSRecord, error) {
-	if len(data) == 0 {
-		return nil, nil, dkvsindexer.ErrBlobManifestInvalid
-	}
-	chunks := chunkBlobData(data, 0)
-	manifest, records, err := BuildDKVSAccountSignedBlobRecords(wallet, objectID, chunks, metadata, opts, autopay)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := p.putWalletBlobRecords(wallet, manifest, records); err != nil {
-		return nil, nil, err
-	}
-	return manifest, records, nil
-}
-
-func (p *SatsNetDKVSClient) GetAccountBlob(accountID, objectID string, policy dkvsindexer.BlobPolicy,
-	opts dkvsindexer.RecordVerificationOptions) (*dkvsindexer.BlobManifest, []byte, error) {
-	manifestKey, err := dkvsindexer.BlobManifestKey(accountID, objectID)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifestRecord, err := p.GetRecord(manifestKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifest, err := dkvsindexer.ParseBlobManifestValue(manifestRecord.Value, policy)
-	if err != nil {
-		return nil, nil, err
-	}
-	prefix := "/blob/" + accountID + "/" + objectID + "/chunk/"
-	chunks, total, err := p.ListRecords(prefix, 0, int(manifest.ChunkCount))
-	if err != nil {
-		return nil, nil, err
-	}
-	if total != int(manifest.ChunkCount) || len(chunks) != int(manifest.ChunkCount) {
-		return nil, nil, dkvsindexer.ErrBlobChunkInvalid
-	}
-	return dkvsindexer.AssembleAccountBlobFromRecords(manifestRecord, chunks, policy, opts)
 }

--- a/sdk/wallet/dkvs_app_client.go
+++ b/sdk/wallet/dkvs_app_client.go
@@ -1,0 +1,232 @@
+package wallet
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sat20-labs/satoshinet/chaincfg/chainhash"
+	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+	swire "github.com/sat20-labs/satoshinet/wire"
+)
+
+type DKVSCASMutationRequest struct {
+	Record       *swire.DKVSRecord `json:"record"`
+	ExpectedHash string            `json:"expected_hash,omitempty"`
+	ExpectAbsent bool              `json:"expect_absent,omitempty"`
+}
+
+type DKVSBatchCASRequest struct {
+	Mutations []DKVSCASMutationRequest `json:"mutations"`
+}
+
+type DKVSBatchCASResult struct {
+	Applied int                 `json:"applied"`
+	Records []*swire.DKVSRecord `json:"records"`
+	Hashes  []string            `json:"hashes"`
+}
+
+type dkvsBatchCASResp struct {
+	dkvsBaseResp
+	Data *DKVSBatchCASResult `json:"data,omitempty"`
+}
+
+type DKVSDirectorySyncRequest struct {
+	Prefix string `json:"prefix"`
+	Cursor []byte `json:"cursor,omitempty"`
+	Limit  uint32 `json:"limit,omitempty"`
+}
+
+type DKVSDirectoryWatchRequest struct {
+	Prefix         string `json:"prefix"`
+	Root           string `json:"root"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
+}
+
+func normalizeDKVSDirectoryPrefix(prefix string) (string, error) {
+	prefix = strings.TrimSuffix(strings.TrimSpace(prefix), "/")
+	if prefix == "" {
+		return "", dkvsindexer.ErrInvalidKey
+	}
+	if _, err := dkvsindexer.ParsePrefix(prefix); err != nil {
+		return "", err
+	}
+	return prefix, nil
+}
+
+func (p *SatsNetDKVSClient) dkvsWritePrecondition(key string) (dkvsindexer.WritePrecondition, *swire.DKVSRecord, error) {
+	record, err := p.GetRecord(key)
+	if err != nil {
+		if errors.Is(err, ErrDKVSRecordNotFound) {
+			return dkvsindexer.WritePrecondition{ExpectAbsent: true}, nil, nil
+		}
+		return dkvsindexer.WritePrecondition{}, nil, err
+	}
+	if record == nil {
+		return dkvsindexer.WritePrecondition{}, nil, dkvsindexer.ErrInvalidRecord
+	}
+	hash := dkvsindexer.RecordHash(record)
+	return dkvsindexer.WritePrecondition{ExpectedHash: &hash}, record, nil
+}
+
+func casMutationRequest(mutation dkvsindexer.CASMutation) (DKVSCASMutationRequest, error) {
+	if mutation.Record == nil || !mutation.Precondition.Valid() {
+		return DKVSCASMutationRequest{}, dkvsindexer.ErrInvalidRecord
+	}
+	req := DKVSCASMutationRequest{Record: mutation.Record, ExpectAbsent: mutation.Precondition.ExpectAbsent}
+	if mutation.Precondition.ExpectedHash != nil {
+		req.ExpectedHash = mutation.Precondition.ExpectedHash.String()
+	}
+	return req, nil
+}
+
+func (p *SatsNetDKVSClient) PutRecordCAS(record *swire.DKVSRecord,
+	precondition dkvsindexer.WritePrecondition) (*swire.DKVSRecord, error) {
+
+	req, err := casMutationRequest(dkvsindexer.CASMutation{Record: record, Precondition: precondition})
+	if err != nil {
+		return nil, err
+	}
+	var resp dkvsRecordResp
+	if err := p.postJSON("/v3/dkvs/records/cas", req, &resp); err != nil {
+		return nil, err
+	}
+	return verifyDKVSWriteEcho(record, resp.Data, resp.Hash)
+}
+
+func (p *SatsNetDKVSClient) PutRecordBatchCAS(mutations []dkvsindexer.CASMutation) (*DKVSBatchCASResult, error) {
+	if len(mutations) == 0 {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	req := DKVSBatchCASRequest{Mutations: make([]DKVSCASMutationRequest, 0, len(mutations))}
+	for _, mutation := range mutations {
+		encoded, err := casMutationRequest(mutation)
+		if err != nil {
+			return nil, err
+		}
+		req.Mutations = append(req.Mutations, encoded)
+	}
+	var resp dkvsBatchCASResp
+	if err := p.postJSON("/v3/dkvs/records/batch-cas", req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Data == nil || (resp.Data.Applied != 0 && resp.Data.Applied != len(mutations)) ||
+		len(resp.Data.Records) != len(mutations) || len(resp.Data.Hashes) != len(mutations) {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	for n, mutation := range mutations {
+		want := dkvsindexer.RecordHash(mutation.Record)
+		if resp.Data.Records[n] == nil || dkvsindexer.RecordHash(resp.Data.Records[n]) != want {
+			return nil, dkvsindexer.ErrInvalidRecord
+		}
+		got, err := chainhash.NewHashFromStr(strings.TrimSpace(resp.Data.Hashes[n]))
+		if err != nil || *got != want {
+			return nil, dkvsindexer.ErrInvalidRecord
+		}
+	}
+	return resp.Data, nil
+}
+
+func (p *SatsNetDKVSClient) SyncDirectory(req DKVSDirectorySyncRequest) (*DKVSSyncPage, error) {
+	prefix, err := normalizeDKVSDirectoryPrefix(req.Prefix)
+	if err != nil {
+		return nil, err
+	}
+	req.Prefix = prefix
+	var resp dkvsSyncResp
+	if err := p.postJSON("/v3/dkvs/sync/directory", req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Data == nil || strings.TrimSpace(resp.Data.Root) == "" {
+		return nil, dkvsindexer.ErrInvalidCheckpoint
+	}
+	return resp.Data, nil
+}
+
+func (p *SatsNetDKVSClient) WatchDirectory(req DKVSDirectoryWatchRequest) (*DKVSWatchResult, error) {
+	prefix, err := normalizeDKVSDirectoryPrefix(req.Prefix)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.Root) == "" {
+		return nil, dkvsindexer.ErrInvalidCheckpoint
+	}
+	req.Prefix = prefix
+	var resp dkvsWatchResp
+	if err := p.postJSON("/v3/dkvs/watch/directory", req, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Data == nil || strings.TrimSpace(resp.Data.Root) == "" {
+		return nil, dkvsindexer.ErrInvalidCheckpoint
+	}
+	return resp.Data, nil
+}
+
+func (p *SatsNetDKVSClient) SyncDirectoryAll(prefix string,
+	opts dkvsindexer.RecordVerificationOptions) ([]*swire.DKVSRecord, string, error) {
+
+	prefix, err := normalizeDKVSDirectoryPrefix(prefix)
+	if err != nil {
+		return nil, "", err
+	}
+	if opts.Now == 0 {
+		opts.Now = uint64(time.Now().UnixMilli())
+	}
+	var cursor []byte
+	rootText := ""
+	byKey := make(map[string]*swire.DKVSRecord)
+	for pageNumber := 0; pageNumber < 10000; pageNumber++ {
+		page, err := p.SyncDirectory(DKVSDirectorySyncRequest{
+			Prefix: prefix, Cursor: cursor, Limit: swire.MaxDKVSRecordsPerMsg,
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		if rootText == "" {
+			rootText = page.Root
+		} else if rootText != page.Root {
+			return nil, "", fmt.Errorf("DKVS directory root changed during pagination")
+		}
+		for _, record := range page.Records {
+			if record == nil || (record.Key != prefix && !strings.HasPrefix(record.Key, prefix+"/")) {
+				return nil, "", dkvsindexer.ErrInvalidKey
+			}
+			if err := dkvsindexer.VerifyRecordForClient(record, opts); err != nil {
+				return nil, "", err
+			}
+			if previous := byKey[record.Key]; previous != nil &&
+				dkvsindexer.RecordHash(previous) != dkvsindexer.RecordHash(record) {
+				return nil, "", fmt.Errorf("conflicting DKVS directory record %s", record.Key)
+			}
+			byKey[record.Key] = record
+		}
+		if page.Done {
+			keys := make([]string, 0, len(byKey))
+			for key := range byKey {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			records := make([]*swire.DKVSRecord, 0, len(keys))
+			for _, key := range keys {
+				records = append(records, byKey[key])
+			}
+			want, err := chainhash.NewHashFromStr(rootText)
+			if err != nil {
+				return nil, "", dkvsindexer.ErrInvalidCheckpoint
+			}
+			computed, err := dkvsindexer.DirectoryRootFromRecords(records, opts.Height)
+			if err != nil || computed != *want {
+				return nil, "", dkvsindexer.ErrInvalidCheckpoint
+			}
+			return records, rootText, nil
+		}
+		if len(page.NextCursor) == 0 || bytes.Equal(page.NextCursor, cursor) {
+			return nil, "", fmt.Errorf("invalid DKVS directory cursor")
+		}
+		cursor = append(cursor[:0], page.NextCursor...)
+	}
+	return nil, "", fmt.Errorf("DKVS directory sync exceeded page limit")
+}

--- a/sdk/wallet/dkvs_blob.go
+++ b/sdk/wallet/dkvs_blob.go
@@ -1,0 +1,188 @@
+package wallet
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/sat20-labs/sat20wallet/sdk/common"
+	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+	swire "github.com/sat20-labs/satoshinet/wire"
+)
+
+var dkvsBlobEnvelopeMagic = []byte{'D', 'K', 'B', '1'}
+
+type DKVSBlob struct {
+	Data     []byte
+	Metadata []byte
+}
+
+// EncodeDKVSBlobValue keeps metadata optional. Raw data is stored without an
+// envelope when metadata is empty, allowing the complete 1 MiB value budget to
+// remain available to ordinary blob users.
+func EncodeDKVSBlobValue(data, metadata []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	if len(metadata) == 0 {
+		if len(data) > swire.MaxDKVSBlobValueSize {
+			return nil, dkvsindexer.ErrRecordTooLarge
+		}
+		return append([]byte(nil), data...), nil
+	}
+	if len(metadata) > int(^uint32(0)) {
+		return nil, dkvsindexer.ErrRecordTooLarge
+	}
+	value := make([]byte, 8+len(metadata)+len(data))
+	copy(value, dkvsBlobEnvelopeMagic)
+	binary.BigEndian.PutUint32(value[4:8], uint32(len(metadata)))
+	copy(value[8:], metadata)
+	copy(value[8+len(metadata):], data)
+	if len(value) > swire.MaxDKVSBlobValueSize {
+		return nil, dkvsindexer.ErrRecordTooLarge
+	}
+	return value, nil
+}
+
+func DecodeDKVSBlobValue(value []byte) (*DKVSBlob, error) {
+	if len(value) == 0 {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	blob := &DKVSBlob{}
+	if len(value) < 8 || !bytes.Equal(value[:4], dkvsBlobEnvelopeMagic) {
+		blob.Data = append([]byte(nil), value...)
+		return blob, nil
+	}
+	metadataSize := int(binary.BigEndian.Uint32(value[4:8]))
+	if metadataSize <= 0 || metadataSize > len(value)-8 {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	blob.Metadata = append([]byte(nil), value[8:8+metadataSize]...)
+	blob.Data = append([]byte(nil), value[8+metadataSize:]...)
+	if len(blob.Data) == 0 {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	return blob, nil
+}
+
+func buildDKVSBlobRecord(wallet common.Wallet, blobKey string, data, metadata []byte,
+	opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, error) {
+
+	accountID, err := dkvsAccountID(wallet)
+	if err != nil {
+		return nil, err
+	}
+	key, err := dkvsindexer.BlobKey(accountID, blobKey)
+	if err != nil {
+		return nil, err
+	}
+	value, err := EncodeDKVSBlobValue(data, metadata)
+	if err != nil {
+		return nil, err
+	}
+	return NewDKVSAccountSignedRecord(wallet, key, value, opts)
+}
+
+func BuildDKVSSignedBlobRecord(wallet common.Wallet, blobKey string, data, metadata []byte,
+	opts dkvsindexer.RecordOptions, autopay DKVSAutopayOptions) (*swire.DKVSRecord, error) {
+
+	accountID, err := dkvsAccountID(wallet)
+	if err != nil {
+		return nil, err
+	}
+	key, err := dkvsindexer.BlobKey(accountID, blobKey)
+	if err != nil {
+		return nil, err
+	}
+	value, err := EncodeDKVSBlobValue(data, metadata)
+	if err != nil {
+		return nil, err
+	}
+	return newDKVSAccountSignedRecordWithAutopay(wallet, key, value, opts, autopay)
+}
+
+func BuildDKVSSignedBlobRecordFreeLocal(wallet common.Wallet, blobKey string, data, metadata []byte,
+	opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, error) {
+
+	if opts.TTL == 0 {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	record, err := buildDKVSBlobRecord(wallet, blobKey, data, metadata, opts)
+	if err != nil {
+		return nil, err
+	}
+	proof, err := dkvsindexer.NewFreeLocalFeeProof(
+		record.Key, "blob", uint32(dkvsindexer.RecordSize(record)), record.ExpiryHeight,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := AttachDKVSFeeProof(record, proof); err != nil {
+		return nil, err
+	}
+	if err := SignDKVSRecord(wallet, record); err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+func (p *SatsNetDKVSClient) PutBlobWithAutopay(wallet common.Wallet, blobKey string, data,
+	metadata []byte, opts dkvsindexer.RecordOptions, autopay DKVSAutopayOptions) (*swire.DKVSRecord, error) {
+
+	record, err := BuildDKVSSignedBlobRecord(wallet, blobKey, data, metadata, opts, autopay)
+	if err != nil {
+		return nil, err
+	}
+	return p.PutRecord(record)
+}
+
+func (p *SatsNetDKVSClient) PutBlobFreeLocal(wallet common.Wallet, blobKey string, data,
+	metadata []byte, opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, error) {
+
+	config, err := p.GetDKVSClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	if !config.FreeLocal.Enabled {
+		return nil, dkvsindexer.ErrFreeLocalDisabled
+	}
+	if opts.TTL == 0 || opts.TTL > config.FreeLocal.MaxTTL {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	value, err := EncodeDKVSBlobValue(data, metadata)
+	if err != nil {
+		return nil, err
+	}
+	if config.Blob.MaxValueSize <= 0 || len(value) > config.Blob.MaxValueSize {
+		return nil, dkvsindexer.ErrRecordTooLarge
+	}
+	record, err := BuildDKVSSignedBlobRecordFreeLocal(wallet, blobKey, data, metadata, opts)
+	if err != nil {
+		return nil, err
+	}
+	return p.PutRecord(record)
+}
+
+func (p *SatsNetDKVSClient) GetBlob(accountID, blobKey string,
+	opts dkvsindexer.RecordVerificationOptions) (*swire.DKVSRecord, *DKVSBlob, error) {
+
+	key, err := dkvsindexer.BlobKey(accountID, blobKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	record, err := p.GetRecord(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	if opts.ExpectedKey == "" {
+		opts.ExpectedKey = key
+	}
+	if err := dkvsindexer.VerifyBlobRecordForClient(record, opts); err != nil {
+		return nil, nil, err
+	}
+	blob, err := DecodeDKVSBlobValue(record.Value)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode DKVS blob: %w", err)
+	}
+	return record, blob, nil
+}

--- a/sdk/wallet/dkvs_client.go
+++ b/sdk/wallet/dkvs_client.go
@@ -46,6 +46,7 @@ type dkvsBaseResp struct {
 type dkvsRecordResp struct {
 	dkvsBaseResp
 	Data *swire.DKVSRecord `json:"data,omitempty"`
+	Hash string            `json:"hash,omitempty"`
 }
 
 type dkvsRecordsResp struct {
@@ -67,7 +68,7 @@ type dkvsUsageResp struct {
 
 type dkvsConfigResp struct {
 	dkvsBaseResp
-	Data *dkvsindexer.FreeLocalCachePolicy `json:"data,omitempty"`
+	Data *dkvsindexer.ClientConfig `json:"data,omitempty"`
 }
 
 type dkvsSubscriptionResp struct {
@@ -220,12 +221,29 @@ func (p *SatsNetDKVSClient) SyncFilteredAll(filters []dkvsindexer.Subscription,
 	return nil, "", fmt.Errorf("DKVS sync exceeded page limit")
 }
 
+func verifyDKVSWriteEcho(request, echoed *swire.DKVSRecord, hashText string) (*swire.DKVSRecord, error) {
+	if request == nil || echoed == nil {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	want := dkvsindexer.RecordHash(request)
+	if dkvsindexer.RecordHash(echoed) != want {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	if strings.TrimSpace(hashText) != "" {
+		got, err := chainhash.NewHashFromStr(strings.TrimSpace(hashText))
+		if err != nil || *got != want {
+			return nil, dkvsindexer.ErrInvalidRecord
+		}
+	}
+	return echoed, nil
+}
+
 func (p *SatsNetDKVSClient) PutRecord(record *swire.DKVSRecord) (*swire.DKVSRecord, error) {
 	var resp dkvsRecordResp
 	if err := p.postJSON("/v3/dkvs/records", record, &resp); err != nil {
 		return nil, err
 	}
-	return resp.Data, nil
+	return verifyDKVSWriteEcho(record, resp.Data, resp.Hash)
 }
 
 func (p *SatsNetDKVSClient) Tombstone(record *swire.DKVSRecord) (*swire.DKVSRecord, error) {
@@ -233,7 +251,7 @@ func (p *SatsNetDKVSClient) Tombstone(record *swire.DKVSRecord) (*swire.DKVSReco
 	if err := p.postJSON("/v3/dkvs/tombstone", record, &resp); err != nil {
 		return nil, err
 	}
-	return resp.Data, nil
+	return verifyDKVSWriteEcho(record, resp.Data, resp.Hash)
 }
 
 func (p *SatsNetDKVSClient) GetRecord(key string) (*swire.DKVSRecord, error) {
@@ -318,14 +336,28 @@ func (p *SatsNetDKVSClient) GetUsage(prefix string) (*dkvsindexer.Usage, error) 
 	return resp.Data, nil
 }
 
-// GetFreeLocalCachePolicy returns the policy of the node this wallet is
-// connected to. It is node-local capacity information, not a network rule.
-func (p *SatsNetDKVSClient) GetFreeLocalCachePolicy() (*dkvsindexer.FreeLocalCachePolicy, error) {
+// GetDKVSClientConfig returns the write and cache policy of the connected
+// node. Applications must treat it as node-local policy, not network consensus.
+func (p *SatsNetDKVSClient) GetDKVSClientConfig() (*dkvsindexer.ClientConfig, error) {
 	var resp dkvsConfigResp
 	if err := p.getPathJSON("/v3/dkvs/config", &resp); err != nil {
 		return nil, err
 	}
+	if resp.Data == nil {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
 	return resp.Data, nil
+}
+
+// GetFreeLocalCachePolicy is retained as a convenience wrapper for callers
+// that only need the FREE_LOCAL portion of the node policy.
+func (p *SatsNetDKVSClient) GetFreeLocalCachePolicy() (*dkvsindexer.FreeLocalCachePolicy, error) {
+	config, err := p.GetDKVSClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	policy := config.FreeLocal
+	return &policy, nil
 }
 
 func (p *SatsNetDKVSClient) GetCheckpoint() (*dkvsindexer.Checkpoint, error) {
@@ -414,6 +446,8 @@ func (p *SatsNetDKVSClient) ListSubscriptions() ([]dkvsindexer.Subscription, err
 
 func newSignedRecordWithAutopay(wallet common.Wallet, key string, value []byte,
 	opts dkvsindexer.RecordOptions, autopay DKVSAutopayOptions) (*swire.DKVSRecord, error) {
+	opts.TTL = 0
+	opts.ExpiryHeight = 0
 	record, err := NewDKVSSignedRecord(wallet, key, value, opts)
 	if err != nil {
 		return nil, err
@@ -654,195 +688,6 @@ func (p *SatsNetDKVSClient) UnsubscribePrefix(prefix string) ([]dkvsindexer.Subs
 		return nil, err
 	}
 	return p.Unsubscribe(dkvsindexer.Subscription{Type: dkvsindexer.SubscriptionPrefix, Target: prefix})
-}
-
-func (p *SatsNetDKVSClient) PutBlobRecords(manifestRecord *swire.DKVSRecord, chunkRecords []*swire.DKVSRecord) error {
-	if _, err := p.PutRecord(manifestRecord); err != nil {
-		return err
-	}
-	for _, record := range chunkRecords {
-		if _, err := p.PutRecord(record); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (p *SatsNetDKVSClient) putWalletBlobRecords(wallet common.Wallet, manifestRecord *swire.DKVSRecord,
-	chunkRecords []*swire.DKVSRecord) error {
-
-	if wallet == nil || manifestRecord == nil {
-		return dkvsindexer.ErrInvalidRecord
-	}
-	if _, err := p.PutRecord(manifestRecord); err != nil {
-		return err
-	}
-	active, err := p.GetRecord(manifestRecord.Key)
-	if err != nil {
-		return err
-	}
-	if active == nil || active.Key != manifestRecord.Key || active.Seq != manifestRecord.Seq ||
-		!bytes.Equal(active.PubKey, manifestRecord.PubKey) ||
-		!bytes.Equal(active.Value, manifestRecord.Value) {
-		return dkvsindexer.ErrBlobManifestInvalid
-	}
-	parsed, err := dkvsindexer.ParseKey(active.Key)
-	if err != nil {
-		return err
-	}
-	if err := dkvsindexer.VerifySignature(active); err != nil {
-		return err
-	}
-	if err := dkvsindexer.ValidateRecordIdentity(active, parsed); err != nil {
-		return err
-	}
-	for _, record := range chunkRecords {
-		if record == nil {
-			return dkvsindexer.ErrInvalidRecord
-		}
-		record.Seq = active.Seq
-		record.IssueTime = active.IssueTime
-		record.TTL = active.TTL
-		record.ExpiryHeight = active.ExpiryHeight
-		record.FeeProof = append(record.FeeProof[:0], active.FeeProof...)
-		if err := SignDKVSRecord(wallet, record); err != nil {
-			return err
-		}
-		if _, err := p.PutRecord(record); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (p *SatsNetDKVSClient) PutBlob(wallet common.Wallet, objectID string, data []byte, metadata []byte, opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, []*swire.DKVSRecord, error) {
-	if len(data) == 0 {
-		return nil, nil, dkvsindexer.ErrBlobManifestInvalid
-	}
-	chunks := chunkBlobData(data, 0)
-	manifestRecord, chunkRecords, err := p.PutChunkedBlob(wallet, objectID, chunks, metadata, opts)
-	if err != nil {
-		return nil, nil, err
-	}
-	return manifestRecord, chunkRecords, nil
-}
-
-// PutBlobWithAutopay attaches a fee proof to the manifest and every chunk,
-// then re-signs each record with the owning wallet before publication.
-func (p *SatsNetDKVSClient) PutBlobWithAutopay(wallet common.Wallet, objectID string, data []byte,
-	metadata []byte, opts dkvsindexer.RecordOptions, autopay DKVSAutopayOptions) (*swire.DKVSRecord, []*swire.DKVSRecord, error) {
-	if len(data) == 0 {
-		return nil, nil, dkvsindexer.ErrBlobManifestInvalid
-	}
-	chunks := chunkBlobData(data, 0)
-	manifestRecord, chunkRecords, err := BuildDKVSSignedBlobRecords(wallet, objectID, chunks, metadata, opts)
-	if err != nil {
-		return nil, nil, err
-	}
-	all := append([]*swire.DKVSRecord{manifestRecord}, chunkRecords...)
-	for _, record := range all {
-		if err := attachDKVSAutopayFeeProof(wallet, record, autopay); err != nil {
-			return nil, nil, err
-		}
-	}
-	if err := p.putWalletBlobRecords(wallet, manifestRecord, chunkRecords); err != nil {
-		return nil, nil, err
-	}
-	return manifestRecord, chunkRecords, nil
-}
-
-func (p *SatsNetDKVSClient) PutBlobFreeLocal(wallet common.Wallet, objectID string, data []byte,
-	metadata []byte, opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, []*swire.DKVSRecord, error) {
-
-	if len(data) == 0 {
-		return nil, nil, dkvsindexer.ErrBlobManifestInvalid
-	}
-	policy, err := p.GetFreeLocalCachePolicy()
-	if err != nil {
-		return nil, nil, err
-	}
-	if policy == nil || !policy.Enabled {
-		return nil, nil, dkvsindexer.ErrFreeLocalDisabled
-	}
-	if opts.TTL == 0 || opts.TTL > policy.MaxTTL {
-		return nil, nil, dkvsindexer.ErrInvalidRecord
-	}
-	chunks := chunkBlobData(data, 0)
-	manifestRecord, chunkRecords, err := BuildDKVSSignedBlobRecords(wallet, objectID, chunks, metadata, opts)
-	if err != nil {
-		return nil, nil, err
-	}
-	all := append([]*swire.DKVSRecord{manifestRecord}, chunkRecords...)
-	for _, record := range all {
-		parsed, parseErr := dkvsindexer.ParseKey(record.Key)
-		if parseErr != nil {
-			return nil, nil, parseErr
-		}
-		proof, proofErr := dkvsindexer.NewFreeLocalFeeProof(
-			record.Key, parsed.Namespace, uint32(dkvsindexer.RecordSize(record)), record.ExpiryHeight,
-		)
-		if proofErr != nil {
-			return nil, nil, proofErr
-		}
-		if attachErr := AttachDKVSFeeProof(record, proof); attachErr != nil {
-			return nil, nil, attachErr
-		}
-		if signErr := SignDKVSRecord(wallet, record); signErr != nil {
-			return nil, nil, signErr
-		}
-	}
-	if err := p.putWalletBlobRecords(wallet, manifestRecord, chunkRecords); err != nil {
-		return nil, nil, err
-	}
-	return manifestRecord, chunkRecords, nil
-}
-
-func (p *SatsNetDKVSClient) PutChunkedBlob(wallet common.Wallet, objectID string, chunks [][]byte, metadata []byte, opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, []*swire.DKVSRecord, error) {
-	manifestRecord, chunkRecords, err := BuildDKVSSignedBlobRecords(wallet, objectID, chunks, metadata, opts)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := p.putWalletBlobRecords(wallet, manifestRecord, chunkRecords); err != nil {
-		return nil, nil, err
-	}
-	return manifestRecord, chunkRecords, nil
-}
-
-func (p *SatsNetDKVSClient) GetBlob(accountID, objectID string, policy dkvsindexer.BlobPolicy) (*dkvsindexer.BlobManifest, []byte, error) {
-	if policy.MaxTotalSize == 0 {
-		policy.MaxTotalSize = dkvsindexer.DefaultBlobMaxTotalSize
-	}
-	if policy.MaxChunkSize == 0 {
-		policy.MaxChunkSize = dkvsindexer.DefaultBlobMaxChunkSize
-	}
-	if policy.MaxChunks == 0 {
-		policy.MaxChunks = dkvsindexer.DefaultBlobMaxChunks
-	}
-	manifestKey, err := dkvsindexer.BlobManifestKey(accountID, objectID)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifestRecord, err := p.GetRecord(manifestKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifest, err := dkvsindexer.ParseBlobManifestValue(manifestRecord.Value, policy)
-	if err != nil {
-		return nil, nil, err
-	}
-	chunkPrefix := "/blob/" + accountID + "/" + objectID + "/chunk/"
-	chunkRecords, total, err := p.ListRecords(chunkPrefix, 0, int(manifest.ChunkCount))
-	if err != nil {
-		return nil, nil, err
-	}
-	if total != int(manifest.ChunkCount) || len(chunkRecords) != int(manifest.ChunkCount) {
-		return nil, nil, dkvsindexer.ErrBlobChunkInvalid
-	}
-	return dkvsindexer.AssembleBlobFromRecords(manifestRecord, chunkRecords, policy)
-}
-
-func (p *SatsNetDKVSClient) GetChunkedBlob(accountID, objectID string, policy dkvsindexer.BlobPolicy) (*dkvsindexer.BlobManifest, []byte, error) {
-	return p.GetBlob(accountID, objectID, policy)
 }
 
 func (p *SatsNetDKVSClient) CreateMailbox(pubKey []byte) (string, error) {
@@ -1164,25 +1009,4 @@ func serviceSubscriptionTarget(serviceName string) (string, error) {
 		return "", err
 	}
 	return target, nil
-}
-
-func chunkBlobData(data []byte, chunkSize int) [][]byte {
-	if chunkSize <= 0 {
-		// MaxDKVSRecordSize limits the complete wire record, not just Value.
-		// Reserve the maximum key/pubkey/signature/fee-proof sizes plus fixed
-		// and varint fields so signed chunks remain serializable at all allowed
-		// DKVS field sizes.
-		chunkSize = swire.MaxDKVSRecordSize - swire.MaxDKVSKeySize - swire.MaxDKVSPubKeySize -
-			swire.MaxDKVSSignatureSize - swire.MaxDKVSFeeProofSize - 64
-	}
-	chunks := make([][]byte, 0, (len(data)+chunkSize-1)/chunkSize)
-	for len(data) > 0 {
-		n := chunkSize
-		if len(data) < n {
-			n = len(data)
-		}
-		chunks = append(chunks, append([]byte{}, data[:n]...))
-		data = data[n:]
-	}
-	return chunks
 }

--- a/sdk/wallet/dkvs_client_test.go
+++ b/sdk/wallet/dkvs_client_test.go
@@ -3,7 +3,9 @@ package wallet
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/sat20-labs/satoshinet/btcec"
@@ -38,6 +40,20 @@ func (c *fakeDKVSHTTPClient) SendPostRequest(url *URL, body []byte) ([]byte, err
 	resp, ok := c.postResp[url.Path]
 	if !ok {
 		return nil, fmt.Errorf("missing post response for %s", url.Path)
+	}
+	if strings.HasSuffix(url.Path, "/v3/dkvs/records") ||
+		strings.HasSuffix(url.Path, "/v3/dkvs/tombstone") {
+		var base dkvsBaseResp
+		if json.Unmarshal(resp, &base) == nil && base.Code == 0 {
+			var record swire.DKVSRecord
+			if err := json.Unmarshal(body, &record); err != nil {
+				return nil, err
+			}
+			hash := dkvsindexer.RecordHash(&record)
+			return json.Marshal(map[string]interface{}{
+				"code": 0, "msg": "ok", "data": &record, "hash": hash.String(),
+			})
+		}
 	}
 	return resp, nil
 }
@@ -285,7 +301,7 @@ func TestSatsNetDKVSClientFreeLocalCachePolicyAndWrite(t *testing.T) {
 	}
 	http := &fakeDKVSHTTPClient{
 		getResp: map[string][]byte{
-			"testnet/v3/dkvs/config": mustJSON(t, map[string]interface{}{"code": 0, "msg": "ok", "data": policy}),
+			"testnet/v3/dkvs/config": mustJSON(t, map[string]interface{}{"code": 0, "msg": "ok", "data": dkvsindexer.ClientConfig{FreeLocal: policy, Blob: dkvsindexer.DefaultBlobPolicy()}}),
 		},
 		postResp: map[string][]byte{
 			"testnet/v3/dkvs/records": mustJSON(t, map[string]interface{}{"code": 0, "msg": "ok"}),
@@ -613,115 +629,54 @@ func TestSatsNetDKVSClientBlob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	wallet := dkvsTestWalletFromPriv(t, priv)
 	accountID := dkvsindexer.AccountID(priv.PubKey().SerializeCompressed())
-	manifestRecord, chunkRecords, err := BuildDKVSSignedBlobRecords(dkvsTestWalletFromPriv(t, priv), "object", [][]byte{[]byte("hello "), []byte("world")}, nil, dkvsindexer.RecordOptions{
-		Seq:          1,
-		TTL:          60_000,
-		ExpiryHeight: 100,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	http := &fakeDKVSHTTPClient{
-		getResp: map[string][]byte{
-			"testnet/v3/dkvs/records":        mustJSON(t, map[string]interface{}{"code": 0, "msg": "ok", "data": manifestRecord}),
-			"testnet/v3/dkvs/records/prefix": mustJSON(t, map[string]interface{}{"code": 0, "msg": "ok", "total": len(chunkRecords), "data": chunkRecords}),
-		},
-		postResp: map[string][]byte{
-			"testnet/v3/dkvs/records": mustJSON(t, map[string]interface{}{"code": 0, "msg": "ok", "data": manifestRecord}),
-		},
-		deleteResp: map[string][]byte{},
-	}
-	client := NewSatsNetDKVSClient("http", "127.0.0.1:8334", "testnet", http)
-	if err := client.PutBlobRecords(manifestRecord, chunkRecords); err != nil {
-		t.Fatal(err)
-	}
-	if http.lastPost.Path != "testnet/v3/dkvs/records" {
-		t.Fatalf("put blob path=%s", http.lastPost.Path)
-	}
-	manifest, content, err := client.GetBlob(accountID, "object", dkvsindexer.BlobPolicy{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if manifest.ChunkCount != 2 || string(content) != "hello world" {
-		t.Fatalf("manifest=%#v content=%q", manifest, string(content))
-	}
-	if http.lastGet.Query["prefix"] != "/blob/"+accountID+"/object/chunk/" {
-		t.Fatalf("chunk query=%v", http.lastGet.Query)
-	}
-
 	memory := newRGB11MemoryDKVSHTTP()
-	writeClient := NewSatsNetDKVSClient("http", "dkvs.test", "testnet", memory)
-	putManifest, putChunks, err := writeClient.PutBlob(dkvsTestWalletFromPriv(t, priv), "recovery-file", []byte("hello world"), nil, dkvsindexer.RecordOptions{Seq: 1, TTL: 60_000, ExpiryHeight: 100})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if putManifest.Key != "/blob/"+accountID+"/recovery-file/manifest" || len(putChunks) != 1 {
-		t.Fatalf("manifest=%s chunks=%d", putManifest.Key, len(putChunks))
-	}
-	if _, _, err := writeClient.PutChunkedBlob(dkvsTestWalletFromPriv(t, priv), "object-2", [][]byte{[]byte("a"), []byte("b")}, nil, dkvsindexer.RecordOptions{Seq: 1, TTL: 60_000, ExpiryHeight: 100}); err != nil {
-		t.Fatal(err)
-	}
-	if _, content, err := client.GetChunkedBlob(accountID, "object", dkvsindexer.BlobPolicy{}); err != nil || string(content) != "hello world" {
-		t.Fatalf("get chunked content=%q err=%v", content, err)
-	}
-}
-
-func TestPutBlobFreeLocalRetriesSameObjectIdempotently(t *testing.T) {
-	priv, err := btcec.NewPrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	http := newRGB11MemoryDKVSHTTP()
-	http.validateBlobChunks = true
-	client := NewSatsNetDKVSClient("http", "dkvs.test", "testnet", http)
-	testWallet := dkvsTestWalletFromPriv(t, priv)
-	firstOpts := dkvsindexer.RecordOptions{Seq: 1, IssueTime: 1_000, TTL: http.freeLocal.MaxTTL}
-	secondOpts := dkvsindexer.RecordOptions{Seq: 1, IssueTime: 2_000, TTL: http.freeLocal.MaxTTL}
+	client := NewSatsNetDKVSClient("http", "dkvs.test", "testnet", memory)
 	data := bytes.Repeat([]byte{0x5a}, 20_000)
-
-	firstManifest, _, err := client.PutBlobFreeLocal(testWallet, "retry-object", data, nil, firstOpts)
+	metadata := []byte("recovery")
+	record, err := client.PutBlobFreeLocal(wallet, "object", data, metadata,
+		dkvsindexer.RecordOptions{Seq: 1, TTL: memory.freeLocal.MaxTTL})
 	if err != nil {
 		t.Fatal(err)
 	}
-	secondManifest, secondChunks, err := client.PutBlobFreeLocal(testWallet, "retry-object", data, nil, secondOpts)
+	if record.Key != "/blob/"+accountID+"/object" {
+		t.Fatalf("blob key=%s", record.Key)
+	}
+	proof, err := dkvsindexer.ParseFeeProof(record.FeeProof)
+	if err != nil || proof.Mode != dkvsindexer.FeeModeFreeLocal {
+		t.Fatalf("proof=%+v err=%v", proof, err)
+	}
+	fetched, blob, err := client.GetBlob(accountID, "object",
+		dkvsindexer.RecordVerificationOptions{Now: record.IssueTime})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if secondManifest.IssueTime == firstManifest.IssueTime {
-		t.Fatal("test did not generate a new candidate manifest issue time")
-	}
-	for index, record := range secondChunks {
-		if record.IssueTime != firstManifest.IssueTime {
-			t.Fatalf("chunk %d issue time=%d want active manifest %d", index, record.IssueTime, firstManifest.IssueTime)
-		}
+	if dkvsindexer.RecordHash(fetched) != dkvsindexer.RecordHash(record) ||
+		!bytes.Equal(blob.Data, data) || !bytes.Equal(blob.Metadata, metadata) {
+		t.Fatal("blob round trip mismatch")
 	}
 }
 
-func TestRGB11BlobDefaultChunksFitMaximumWireRecord(t *testing.T) {
+func TestDKVSBlobMaximumValueBoundary(t *testing.T) {
 	priv, err := btcec.NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	data := bytes.Repeat([]byte{0x5a}, swire.MaxDKVSRecordSize*3)
-	chunks := chunkBlobData(data, 0)
-	if len(chunks) < 4 {
-		t.Fatalf("expected conservative DKVS chunking, got %d chunks", len(chunks))
-	}
-	_, records, err := BuildDKVSSignedBlobRecords(
-		dkvsTestWalletFromPriv(t, priv), "rgb11-wallet-snapshot-maximum-size", chunks, nil,
-		dkvsindexer.RecordOptions{
-			Seq: 1, TTL: 60_000, ExpiryHeight: 100,
-			FeeProof: bytes.Repeat([]byte{0x01}, swire.MaxDKVSFeeProofSize),
-		},
-	)
+	wallet := dkvsTestWalletFromPriv(t, priv)
+	exact := bytes.Repeat([]byte{0x7a}, swire.MaxDKVSBlobValueSize)
+	record, err := BuildDKVSSignedBlobRecordFreeLocal(wallet, "maximum", exact, nil,
+		dkvsindexer.RecordOptions{Seq: 1, TTL: 60_000})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for index, record := range records {
-		if size := dkvsindexer.RecordSize(record); size > swire.MaxDKVSRecordSize {
-			t.Fatalf("chunk %d wire size=%d max=%d", index, size, swire.MaxDKVSRecordSize)
-		}
+	if len(record.Value) != swire.MaxDKVSBlobValueSize ||
+		dkvsindexer.RecordSize(record) > swire.MaxDKVSBlobRecordSize {
+		t.Fatalf("blob value=%d record=%d", len(record.Value), dkvsindexer.RecordSize(record))
+	}
+	if _, err := BuildDKVSSignedBlobRecordFreeLocal(wallet, "too-large",
+		append(exact, 0), nil, dkvsindexer.RecordOptions{Seq: 1, TTL: 60_000}); !errors.Is(err, dkvsindexer.ErrRecordTooLarge) {
+		t.Fatalf("oversized blob error=%v", err)
 	}
 }
 

--- a/sdk/wallet/dkvs_config_compat.go
+++ b/sdk/wallet/dkvs_config_compat.go
@@ -1,9 +1,9 @@
 package wallet
 
-// AccountFreeLocalPolicy mirrors the public JSON returned by the connected
-// indexer's GET /v3/dkvs/config endpoint. Keeping this transport type in the
-// wallet SDK avoids coupling PWA account management to an indexer-internal Go
-// type while preserving the endpoint contract.
+import dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
+
+// AccountFreeLocalPolicy is the wallet-facing projection of the connected
+// node's FREE_LOCAL section from GET /v3/dkvs/config.
 type AccountFreeLocalPolicy struct {
 	Enabled             bool   `json:"enabled"`
 	MaxTTL              uint64 `json:"max_ttl_ms"`
@@ -15,11 +15,10 @@ type AccountFreeLocalPolicy struct {
 
 type accountDKVSConfigResp struct {
 	dkvsBaseResp
-	Data *AccountFreeLocalPolicy `json:"data,omitempty"`
+	Data *dkvsindexer.ClientConfig `json:"data,omitempty"`
 }
 
-// GetConfig reads the cache policy of the node to which this wallet is
-// connected. It is node-local configuration, not a network-wide guarantee.
+// GetConfig reads the FREE_LOCAL cache policy of the connected node.
 func (p *SatsNetDKVSClient) GetConfig() (*AccountFreeLocalPolicy, error) {
 	var resp accountDKVSConfigResp
 	if err := p.getPathJSON("/v3/dkvs/config", &resp); err != nil {
@@ -28,5 +27,13 @@ func (p *SatsNetDKVSClient) GetConfig() (*AccountFreeLocalPolicy, error) {
 	if resp.Data == nil {
 		return nil, ErrDKVSRecordNotFound
 	}
-	return resp.Data, nil
+	policy := resp.Data.FreeLocal
+	return &AccountFreeLocalPolicy{
+		Enabled:             policy.Enabled,
+		MaxTTL:              policy.MaxTTL,
+		MaxRecordsPerSigner: policy.MaxRecordsPerSigner,
+		MaxBytesPerSigner:   policy.MaxBytesPerSigner,
+		MaxTotalRecords:     policy.MaxTotalRecords,
+		MaxTotalBytes:       policy.MaxTotalBytes,
+	}, nil
 }

--- a/sdk/wallet/dkvs_config_test.go
+++ b/sdk/wallet/dkvs_config_test.go
@@ -19,12 +19,18 @@ func TestSatsNetDKVSClientGetConfig(t *testing.T) {
 			"code": 0,
 			"msg":  "ok",
 			"data": map[string]any{
-				"enabled":                true,
-				"max_ttl_ms":             60000,
-				"max_records_per_signer": 10,
-				"max_bytes_per_signer":   4096,
-				"max_total_records":      100,
-				"max_total_bytes":        65536,
+				"free_local": map[string]any{
+					"enabled":                true,
+					"max_ttl_ms":             60000,
+					"max_records_per_signer": 10,
+					"max_bytes_per_signer":   4096,
+					"max_total_records":      100,
+					"max_total_bytes":        65536,
+				},
+				"blob": map[string]any{
+					"max_value_size":                 1048576,
+					"max_free_local_keys_per_signer": 1,
+				},
 			},
 		}))
 	}))

--- a/sdk/wallet/dkvs_paid_retention_test.go
+++ b/sdk/wallet/dkvs_paid_retention_test.go
@@ -20,18 +20,13 @@ func TestAttachAutopayFeeProofClearsRecordLease(t *testing.T) {
 	require.Equal(t, dkvsindexer.FeeModeAutopay, decoded.Mode)
 }
 
-func TestAttachAutopayFeeProofRewritesBlobManifestLease(t *testing.T) {
-	_, value, err := dkvsindexer.BuildBlobManifest([][]byte{[]byte("chunk")}, []byte("meta"), 60_000, 12345)
+func TestAttachAutopayFeeProofClearsBlobLease(t *testing.T) {
+	key, err := dkvsindexer.BlobKey(strings.Repeat("a", 64), "object")
 	require.NoError(t, err)
-	key, err := dkvsindexer.BlobManifestKey(strings.Repeat("a", 64), "object")
-	require.NoError(t, err)
-	record := &swire.DKVSRecord{Key: key, Value: value, TTL: 60_000, ExpiryHeight: 12345}
+	record := &swire.DKVSRecord{Key: key, Value: []byte("blob"), TTL: 60_000, ExpiryHeight: 12345}
 	proof := &dkvsindexer.FeeProof{Mode: dkvsindexer.FeeModeAutopay, PoolContract: "autopay"}
 	require.NoError(t, AttachDKVSFeeProof(record, proof))
-	manifest, err := dkvsindexer.ParseBlobManifestValue(record.Value, dkvsindexer.BlobPolicy{})
-	require.NoError(t, err)
-	require.Zero(t, manifest.TTL)
-	require.Zero(t, manifest.ExpiryHeight)
+	require.Equal(t, []byte("blob"), record.Value)
 	require.Zero(t, record.TTL)
 	require.Zero(t, record.ExpiryHeight)
 }

--- a/sdk/wallet/dkvs_signing.go
+++ b/sdk/wallet/dkvs_signing.go
@@ -140,17 +140,6 @@ func AttachDKVSFeeProof(record *swire.DKVSRecord, proof *dkvsindexer.FeeProof) e
 	if proof.Mode == dkvsindexer.FeeModeAutopay {
 		// Paid retention is driven by the payer's successful payment in every
 		// block. AUTOPAY records therefore have no record-level TTL or expiry.
-		parsed, err := dkvsindexer.ParseKey(record.Key)
-		if err != nil {
-			return err
-		}
-		if parsed.Namespace == "blob" && len(parsed.Segments) == 3 && parsed.Segments[2] == "manifest" {
-			value, err := dkvsindexer.RewriteBlobManifestRetention(record.Value, 0, 0)
-			if err != nil {
-				return err
-			}
-			record.Value = value
-		}
 		record.TTL = 0
 		record.ExpiryHeight = 0
 	}
@@ -160,44 +149,6 @@ func AttachDKVSFeeProof(record *swire.DKVSRecord, proof *dkvsindexer.FeeProof) e
 	}
 	record.FeeProof = encoded
 	return nil
-}
-
-func BuildDKVSSignedBlobRecords(wallet common.Wallet, objectID string, chunks [][]byte, metadata []byte, opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, []*swire.DKVSRecord, error) {
-	pubKey, err := dkvsWalletPubKey(wallet)
-	if err != nil {
-		return nil, nil, dkvsindexer.ErrInvalidSignature
-	}
-	// A blob is one logical wallet-signed object. Its manifest and every chunk
-	// must share the same issue time or client-side assembly will reject it.
-	if opts.IssueTime == 0 {
-		opts.IssueTime = uint64(time.Now().UnixMilli())
-	}
-	accountID := dkvsindexer.AccountID(pubKey)
-	manifest, manifestValue, err := dkvsindexer.BuildBlobManifest(chunks, metadata, opts.TTL, opts.ExpiryHeight)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifestKey, err := dkvsindexer.BlobManifestKey(accountID, objectID)
-	if err != nil {
-		return nil, nil, err
-	}
-	manifestRecord, err := NewDKVSSignedRecord(wallet, manifestKey, manifestValue, opts)
-	if err != nil {
-		return nil, nil, err
-	}
-	chunkRecords := make([]*swire.DKVSRecord, 0, manifest.ChunkCount)
-	for n, chunk := range chunks {
-		chunkKey, err := dkvsindexer.BlobChunkKey(accountID, objectID, uint32(n))
-		if err != nil {
-			return nil, nil, err
-		}
-		chunkRecord, err := NewDKVSSignedRecord(wallet, chunkKey, chunk, opts)
-		if err != nil {
-			return nil, nil, err
-		}
-		chunkRecords = append(chunkRecords, chunkRecord)
-	}
-	return manifestRecord, chunkRecords, nil
 }
 
 func dkvsWalletPubKey(wallet common.Wallet) ([]byte, error) {

--- a/sdk/wallet/dkvs_sync_service.go
+++ b/sdk/wallet/dkvs_sync_service.go
@@ -15,6 +15,13 @@ const (
 	dkvsSyncRetryDelay      = 5 * time.Second
 )
 
+type dkvsDirectoryState struct {
+	Prefix  string
+	Root    string
+	Scope   string
+	Filters []dkvsindexer.Subscription
+}
+
 func (p *Manager) dkvsReplicaNamespace() string {
 	if p == nil || p.cfg == nil || p.cfg.IndexerL2 == nil {
 		return ""
@@ -25,8 +32,8 @@ func (p *Manager) dkvsReplicaNamespace() string {
 	}, ":")
 }
 
-func (p *Manager) rgb11HeadFilters() ([]dkvsindexer.Subscription, error) {
-	filters := make([]dkvsindexer.Subscription, 0)
+func (p *Manager) rgb11HeadDirectories() ([]string, error) {
+	directories := make([]string, 0)
 	seen := make(map[string]struct{})
 	for _, account := range p.localRGB11Accounts() {
 		manager, err := p.newScopedRGB11Manager(account)
@@ -44,15 +51,14 @@ func (p *Manager) rgb11HeadFilters() ([]dkvsindexer.Subscription, error) {
 		if err != nil {
 			return nil, err
 		}
-		if _, ok := seen[key]; ok {
+		prefix := strings.TrimSuffix(key, "/head")
+		if _, ok := seen[prefix]; ok {
 			continue
 		}
-		seen[key] = struct{}{}
-		filters = append(filters, dkvsindexer.Subscription{
-			Type: dkvsindexer.SubscriptionKey, Target: key,
-		})
+		seen[prefix] = struct{}{}
+		directories = append(directories, prefix)
 	}
-	return filters, nil
+	return directories, nil
 }
 
 func (p *Manager) flushDKVSOutbox(client *SatsNetDKVSClient, store *dkvsReplicaStore,
@@ -92,49 +98,56 @@ func (p *Manager) flushDKVSOutbox(client *SatsNetDKVSClient, store *dkvsReplicaS
 	return submitted, nil
 }
 
-func (p *Manager) syncDKVSOnce(ctx context.Context) ([]dkvsindexer.Subscription, string, error) {
+func (p *Manager) syncDKVSOnce(ctx context.Context) ([]dkvsDirectoryState, error) {
 	if p == nil || p.rgbManager == nil {
-		return nil, "", fmt.Errorf("wallet manager is unavailable")
+		return nil, fmt.Errorf("wallet manager is unavailable")
 	}
 	p.dkvsSyncRun.Lock()
 	defer p.dkvsSyncRun.Unlock()
-	filters, err := p.rgb11HeadFilters()
+	directories, err := p.rgb11HeadDirectories()
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	if len(filters) == 0 {
-		return nil, "", nil
+	if len(directories) == 0 {
+		return nil, nil
 	}
 	client, err := p.rgbManager.rgb11DKVSClient()
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	store := newDKVSReplicaStore(p.db)
-	scope := dkvsReplicaScope(p.dkvsReplicaNamespace(), filters)
-	pull := func() (string, error) {
-		records, root, err := client.SyncFilteredAll(filters,
-			dkvsindexer.RecordVerificationOptions{Now: uint64(time.Now().UnixMilli())})
+	states := make([]dkvsDirectoryState, 0, len(directories))
+	for _, prefix := range directories {
+		filters := []dkvsindexer.Subscription{{Type: dkvsindexer.SubscriptionPrefix, Target: prefix}}
+		scope := dkvsReplicaScope(p.dkvsReplicaNamespace(), filters)
+		pull := func() (string, error) {
+			records, root, err := client.SyncDirectoryAll(prefix,
+				dkvsindexer.RecordVerificationOptions{Now: uint64(time.Now().UnixMilli())})
+			if err != nil {
+				return "", err
+			}
+			if err := store.applyConfirmed(scope, filters, records, root); err != nil {
+				return "", err
+			}
+			return root, nil
+		}
+		root, err := pull()
 		if err != nil {
-			return "", err
+			return states, err
 		}
-		if err := store.applyConfirmed(scope, filters, records, root); err != nil {
-			return "", err
-		}
-		return root, nil
-	}
-	root, err := pull()
-	if err != nil {
-		return filters, "", err
-	}
-	submitted, err := p.flushDKVSOutbox(client, store, scope)
-	if err != nil {
-		return filters, root, err
-	}
-	if submitted {
-		root, err = pull()
+		submitted, err := p.flushDKVSOutbox(client, store, scope)
 		if err != nil {
-			return filters, "", err
+			return states, err
 		}
+		if submitted {
+			root, err = pull()
+			if err != nil {
+				return states, err
+			}
+		}
+		states = append(states, dkvsDirectoryState{
+			Prefix: prefix, Root: root, Scope: scope, Filters: filters,
+		})
 	}
 	result := p.SyncLocalRGB11State(ctx)
 	for _, account := range result.Accounts {
@@ -149,13 +162,13 @@ func (p *Manager) syncDKVSOnce(ctx context.Context) ([]dkvsindexer.Subscription,
 	if callback != nil {
 		callback()
 	}
-	return filters, root, nil
+	return states, nil
 }
 
 func (p *Manager) runDKVSBackgroundSync(ctx context.Context, done chan struct{}) {
 	defer close(done)
 	for {
-		filters, root, err := p.syncDKVSOnce(ctx)
+		states, err := p.syncDKVSOnce(ctx)
 		if err != nil {
 			Log.Warningf("DKVS background sync failed: %v", err)
 			select {
@@ -165,7 +178,7 @@ func (p *Manager) runDKVSBackgroundSync(ctx context.Context, done chan struct{})
 				continue
 			}
 		}
-		if len(filters) == 0 || root == "" {
+		if len(states) == 0 {
 			select {
 			case <-ctx.Done():
 				return
@@ -177,24 +190,28 @@ func (p *Manager) runDKVSBackgroundSync(ctx context.Context, done chan struct{})
 		if err != nil {
 			continue
 		}
+		watchSeconds := dkvsWatchTimeoutSeconds / len(states)
+		if watchSeconds < 1 {
+			watchSeconds = 1
+		}
 		watchFailed := false
-		for {
-			watch, watchErr := client.WatchFiltered(DKVSWatchRequest{
-				Filters: filters, Root: root, TimeoutSeconds: dkvsWatchTimeoutSeconds,
+		for _, state := range states {
+			watch, watchErr := client.WatchDirectory(DKVSDirectoryWatchRequest{
+				Prefix: state.Prefix, Root: state.Root, TimeoutSeconds: watchSeconds,
 			})
-			if watchErr == nil && watch != nil && !watch.Changed && watch.Root == root {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-					continue
-				}
-			}
 			if watchErr != nil {
-				Log.Warningf("DKVS watch failed: %v", watchErr)
+				Log.Warningf("DKVS directory watch failed: %v", watchErr)
 				watchFailed = true
+				break
 			}
-			break
+			if watch == nil || watch.Changed || watch.Root != state.Root {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 		}
 		if watchFailed {
 			select {
@@ -202,11 +219,6 @@ func (p *Manager) runDKVSBackgroundSync(ctx context.Context, done chan struct{})
 				return
 			case <-time.After(dkvsSyncRetryDelay):
 			}
-		}
-		select {
-		case <-ctx.Done():
-			return
-		default:
 		}
 	}
 }

--- a/sdk/wallet/rgb11_address_transfer_test.go
+++ b/sdk/wallet/rgb11_address_transfer_test.go
@@ -370,8 +370,8 @@ func TestRGB11AddressTransferSchemeA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !pending.State.DeliveryAcknowledged || len(pending.RecipientConsignment) == 0 || pending.State.DeliveryCacheCompacted {
-		t.Fatalf("pre-confirmation sender state=%+v consignment=%d", pending.State, len(pending.RecipientConsignment))
+	if !pending.State.DeliveryAcknowledged || pending.State.DeliveryCacheCompacted {
+		t.Fatalf("pre-confirmation sender state=%+v", pending.State)
 	}
 
 	evidence.setStatus(witnessTxID, rgb11wallet.BitcoinTxStatus{

--- a/sdk/wallet/rgb11_dkvs.go
+++ b/sdk/wallet/rgb11_dkvs.go
@@ -466,36 +466,83 @@ func (p *rgb11Manager) DeliverRGB11AddressTransfer(client *SatsNetDKVSClient, tr
 	}
 	mode := rgb11AddressEnvelopeInline
 	objectID := ""
-	revisionKeys := []string{pending.State.DeliveryRecordKey}
+	mailKey, err := dkvsindexer.MailMsgKey(
+		pending.State.ReceiverAccountID, pending.State.SenderAccountID, messageID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	revisionKeys := []string{mailKey}
+	var blobKey string
 	if len(ciphertext)+2 > inlineLimit {
 		mode = rgb11AddressEnvelopeBlob
 		objectID = messageID
-		manifestKey, err := dkvsindexer.BlobManifestKey(pending.State.SenderAccountID, objectID)
+		blobKey, err = dkvsindexer.BlobKey(pending.State.SenderAccountID, objectID)
 		if err != nil {
 			return nil, err
 		}
-		revisionKeys = append(revisionKeys, manifestKey)
+		revisionKeys = append(revisionKeys, blobKey)
 	}
 	opts := nextRGB11AddressRecordOptions(client, revisionKeys, options.RecordOptions)
-	if mode == rgb11AddressEnvelopeBlob {
-		if _, _, err := client.PutAccountBlob(
-			p.wallet, objectID, ciphertext, nil, opts, options.Autopay,
-		); err != nil {
-			return nil, err
-		}
-	}
 	mailValue, err := rgb11wallet.EncodeAddressEnvelope(mode, ciphertext)
 	if err != nil {
 		return nil, err
 	}
 	if mode == rgb11AddressEnvelopeBlob {
-		mailValue, _ = rgb11wallet.EncodeAddressEnvelope(mode, nil)
+		mailValue, err = rgb11wallet.EncodeAddressEnvelope(mode, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
-	record, err := client.SendAccountMailboxMessage(
-		p.wallet, pending.State.ReceiverAccountID, messageID, mailValue, opts, options.Autopay,
-	)
+	var mailRecord *swire.DKVSRecord
+	if options.Autopay != nil {
+		mailRecord, err = newDKVSAccountSignedRecordWithAutopay(
+			p.wallet, mailKey, mailValue, opts, *options.Autopay,
+		)
+	} else {
+		mailRecord, err = newDKVSAccountSignedRecordWithFreeLocal(
+			p.wallet, mailKey, mailValue, opts,
+		)
+	}
 	if err != nil {
 		return nil, err
+	}
+	mailPrecondition, _, err := client.dkvsWritePrecondition(mailKey)
+	if err != nil {
+		return nil, err
+	}
+	record := mailRecord
+	if mode == rgb11AddressEnvelopeBlob {
+		var blobRecord *swire.DKVSRecord
+		if options.Autopay != nil {
+			blobRecord, err = BuildDKVSSignedBlobRecord(
+				p.wallet, objectID, ciphertext, nil, opts, *options.Autopay,
+			)
+		} else {
+			blobRecord, err = BuildDKVSSignedBlobRecordFreeLocal(
+				p.wallet, objectID, ciphertext, nil, opts,
+			)
+		}
+		if err != nil {
+			return nil, err
+		}
+		blobPrecondition, _, err := client.dkvsWritePrecondition(blobKey)
+		if err != nil {
+			return nil, err
+		}
+		result, err := client.PutRecordBatchCAS([]dkvsindexer.CASMutation{
+			{Record: blobRecord, Precondition: blobPrecondition},
+			{Record: mailRecord, Precondition: mailPrecondition},
+		})
+		if err != nil {
+			return nil, err
+		}
+		record = result.Records[1]
+	} else {
+		record, err = client.PutRecordCAS(mailRecord, mailPrecondition)
+		if err != nil {
+			return nil, err
+		}
 	}
 	recordHash := dkvsindexer.RecordHash(record)
 	modeName := "inline"
@@ -606,10 +653,11 @@ func (p *rgb11Manager) readRGB11AddressConsignment(client *SatsNetDKVSClient, re
 	modeName := "inline"
 	if mode == rgb11AddressEnvelopeBlob {
 		modeName = "blob"
-		_, encrypted, err = client.GetAccountBlob(senderID, messageID, dkvsindexer.DefaultBlobPolicy(), verify)
-		if err != nil {
-			return nil, "", fmt.Errorf("%w: %v", ErrRGB11AddressMailbox, err)
+		_, blob, blobErr := client.GetBlob(senderID, messageID, verify)
+		if blobErr != nil || blob == nil {
+			return nil, "", fmt.Errorf("%w: %v", ErrRGB11AddressMailbox, blobErr)
 		}
+		encrypted = blob.Data
 	}
 	cryptor, ok := p.wallet.(rgb11AccountPayloadCryptor)
 	if !ok {
@@ -1155,23 +1203,76 @@ func (p *rgb11Manager) BackupRGB11WalletState(client *SatsNetDKVSClient, walletI
 	if err != nil {
 		return nil, nil, err
 	}
-	keepOperationIDs := [][32]byte{operationID}
-	if previous != nil {
-		keepOperationIDs = append(keepOperationIDs, previous.OperationID)
-	}
-	if err := client.pruneRGB11WalletSnapshots(p.wallet, walletID, previous, keepOperationIDs...); err != nil {
+	headKey, err := dkvsindexer.PersonalKey(pubkey, RGB11WalletHeadPath(walletID))
+	if err != nil {
 		return nil, nil, err
 	}
-	paid, _ := p.hasActiveRGB11Autopay()
-	var record *swire.DKVSRecord
+	headPrecondition, activeHeadRecord, err := client.dkvsWritePrecondition(headKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if previous == nil {
+		if activeHeadRecord != nil {
+			return nil, nil, coresync.ErrHeadConflict
+		}
+	} else {
+		if activeHeadRecord == nil {
+			return nil, nil, coresync.ErrHeadConflict
+		}
+		activeHead, decodeErr := rgb11wallet.DecodeWalletHead(activeHeadRecord.Value)
+		if decodeErr != nil || activeHeadRecord.Seq != activeHead.Seq || *activeHead != *previous {
+			return nil, nil, coresync.ErrHeadConflict
+		}
+	}
+
+	accountID := dkvsindexer.AccountID(pubkey)
+	snapshotName := RGB11WalletSnapshotBlobKey(walletID)
+	snapshotKey, err := dkvsindexer.BlobKey(accountID, snapshotName)
+	if err != nil {
+		return nil, nil, err
+	}
+	snapshotPrecondition, activeSnapshotRecord, err := client.dkvsWritePrecondition(snapshotKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if previous == nil {
+		if activeSnapshotRecord != nil {
+			return nil, nil, coresync.ErrHeadConflict
+		}
+	} else {
+		if activeSnapshotRecord == nil {
+			return nil, nil, coresync.ErrHeadConflict
+		}
+		if verifyErr := dkvsindexer.VerifyBlobRecordForClient(activeSnapshotRecord,
+			dkvsindexer.RecordVerificationOptions{Now: uint64(time.Now().UnixMilli())}); verifyErr != nil {
+			return nil, nil, verifyErr
+		}
+		activeBlob, decodeErr := DecodeDKVSBlobValue(activeSnapshotRecord.Value)
+		if decodeErr != nil {
+			return nil, nil, decodeErr
+		}
+		activeWalletID, activeOperationID, _, decodeErr := rgb11wallet.DecodeEncryptedSnapshot(activeBlob.Data)
+		if decodeErr != nil || activeWalletID != walletID || activeOperationID != previous.OperationID {
+			return nil, nil, coresync.ErrHeadConflict
+		}
+	}
+
+	paid, err := p.hasActiveRGB11Autopay()
+	if err != nil {
+		return nil, nil, err
+	}
+	opts.Seq = head.Seq
+	var snapshotRecord, headRecord *swire.DKVSRecord
 	if paid {
 		autopay := DKVSAutopayOptions{AddressParams: GetChainParam_SatsNet()}
 		opts.TTL = 0
 		opts.ExpiryHeight = 0
-		if _, err := client.PutRGB11WalletSnapshotWithAutopay(p.wallet, walletID, operationID, envelope, opts, autopay); err != nil {
-			return nil, nil, err
+		snapshotRecord, err = BuildDKVSSignedBlobRecord(
+			p.wallet, snapshotName, envelope, nil, opts, autopay,
+		)
+		if err == nil {
+			headRecord, err = buildRGB11WalletHeadRecord(p.wallet, head, opts, &autopay, false)
 		}
-		record, err = client.PutRGB11WalletHeadWithAutopay(p.wallet, head, opts, autopay)
 		p.setRGB11BackupRetention("autopay", 0)
 	} else {
 		policy, policyErr := client.GetFreeLocalCachePolicy()
@@ -1185,25 +1286,31 @@ func (p *rgb11Manager) BackupRGB11WalletState(client *SatsNetDKVSClient, walletI
 			opts.TTL = policy.MaxTTL
 		}
 		opts.ExpiryHeight = 0
-		if _, err := client.PutRGB11WalletSnapshotFreeLocal(p.wallet, walletID, operationID, envelope, opts); err != nil {
-			return nil, nil, err
+		snapshotRecord, err = BuildDKVSSignedBlobRecordFreeLocal(
+			p.wallet, snapshotName, envelope, nil, opts,
+		)
+		if err == nil {
+			headRecord, err = buildRGB11WalletHeadRecord(p.wallet, head, opts, nil, true)
 		}
-		record, err = client.PutRGB11WalletHeadFreeLocal(p.wallet, head, opts)
 		p.setRGB11BackupRetention("temporary", opts.TTL)
 	}
 	if err != nil {
 		return nil, nil, err
 	}
+	result, err := client.PutRecordBatchCAS([]dkvsindexer.CASMutation{
+		{Record: snapshotRecord, Precondition: snapshotPrecondition},
+		{Record: headRecord, Precondition: headPrecondition},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	record := result.Records[1]
 	if err := p.persistRGB11WalletHead(head); err != nil {
 		p.rgbManager.dkvsStatus = "warning"
 		return nil, nil, err
 	}
 	p.rgbManager.head = head
-	if err := client.pruneRGB11WalletSnapshots(p.wallet, walletID, head, operationID); err != nil {
-		p.rgbManager.dkvsStatus = "warning"
-	} else {
-		p.rgbManager.dkvsStatus = "synced"
-	}
+	p.rgbManager.dkvsStatus = "synced"
 	return head, record, nil
 }
 
@@ -1745,6 +1852,10 @@ func RGB11WalletHeadPath(walletID string) string {
 	return "rgb11/" + dkvsindexer.NormalizeNameID(walletID) + "/head"
 }
 
+func RGB11WalletSnapshotBlobKey(walletID string) string {
+	return dkvsindexer.NormalizeNameID("rgb11-wallet-snapshot:" + walletID)
+}
+
 func (p *SatsNetDKVSClient) PutRGB11WalletHead(wallet common.Wallet, head *coresync.WalletHead, opts dkvsindexer.RecordOptions) (*swire.DKVSRecord, error) {
 	return p.putRGB11WalletHead(wallet, head, opts, nil, false)
 }
@@ -1759,13 +1870,21 @@ func (p *SatsNetDKVSClient) PutRGB11WalletHeadFreeLocal(wallet common.Wallet, he
 	return p.putRGB11WalletHead(wallet, head, opts, nil, true)
 }
 
-func (p *SatsNetDKVSClient) putRGB11WalletHead(wallet common.Wallet, head *coresync.WalletHead,
-	opts dkvsindexer.RecordOptions, autopay *DKVSAutopayOptions, freeLocal bool) (*swire.DKVSRecord, error) {
+func buildRGB11WalletHeadRecord(wallet common.Wallet, head *coresync.WalletHead,
+	opts dkvsindexer.RecordOptions, autopay *DKVSAutopayOptions,
+	freeLocal bool) (*swire.DKVSRecord, error) {
+	if wallet == nil || head == nil {
+		return nil, dkvsindexer.ErrInvalidRecord
+	}
+	if err := VerifyRGB11WalletHead(head, head.WalletID); err != nil {
+		return nil, err
+	}
 	pubKey, err := dkvsWalletPubKey(wallet)
 	if err != nil {
 		return nil, err
 	}
-	if err := VerifyRGB11WalletHead(head, head.WalletID); err != nil {
+	key, err := dkvsindexer.PersonalKey(pubKey, RGB11WalletHeadPath(head.WalletID))
+	if err != nil {
 		return nil, err
 	}
 	value, err := head.StrictEncode()
@@ -1773,14 +1892,27 @@ func (p *SatsNetDKVSClient) putRGB11WalletHead(wallet common.Wallet, head *cores
 		return nil, err
 	}
 	opts.Seq = head.Seq
-	var posted *swire.DKVSRecord
-	if freeLocal {
-		posted, err = p.PutPersonalRecordFreeLocal(wallet, RGB11WalletHeadPath(head.WalletID), value, opts)
-	} else if autopay == nil {
-		posted, err = p.PutPersonalRecord(wallet, RGB11WalletHeadPath(head.WalletID), value, opts)
-	} else {
-		posted, err = p.PutPersonalRecordWithAutopay(wallet, RGB11WalletHeadPath(head.WalletID), value, opts, *autopay)
+	switch {
+	case freeLocal:
+		return newDKVSAccountSignedRecordWithFreeLocal(wallet, key, value, opts)
+	case autopay != nil:
+		return newDKVSAccountSignedRecordWithAutopay(wallet, key, value, opts, *autopay)
+	default:
+		return NewDKVSAccountSignedRecord(wallet, key, value, opts)
 	}
+}
+
+func (p *SatsNetDKVSClient) putRGB11WalletHead(wallet common.Wallet, head *coresync.WalletHead,
+	opts dkvsindexer.RecordOptions, autopay *DKVSAutopayOptions, freeLocal bool) (*swire.DKVSRecord, error) {
+	pubKey, err := dkvsWalletPubKey(wallet)
+	if err != nil {
+		return nil, err
+	}
+	posted, err := buildRGB11WalletHeadRecord(wallet, head, opts, autopay, freeLocal)
+	if err != nil {
+		return nil, err
+	}
+	posted, err = p.PutRecord(posted)
 	if err != nil {
 		return nil, err
 	}
@@ -1868,44 +2000,65 @@ func (p *SatsNetDKVSClient) PutRGB11WalletSnapshotFreeLocal(wallet common.Wallet
 func (p *SatsNetDKVSClient) putRGB11WalletSnapshot(wallet common.Wallet, walletID string,
 	operationID [32]byte, value []byte, opts dkvsindexer.RecordOptions,
 	autopay *DKVSAutopayOptions, freeLocal bool) (*swire.DKVSRecord, error) {
-	if len(value) == 0 {
+	if len(value) == 0 || walletID == "" {
 		return nil, dkvsindexer.ErrInvalidRecord
 	}
-	opts.Seq = 1
-	var manifest *swire.DKVSRecord
-	var err error
-	metadata := rgb11WalletSnapshotMetadata(walletID)
-	if freeLocal {
-		manifest, _, err = p.PutBlobFreeLocal(wallet, hex.EncodeToString(operationID[:]), value, metadata, opts)
-	} else if autopay == nil {
-		manifest, _, err = p.PutBlob(wallet, hex.EncodeToString(operationID[:]), value, metadata, opts)
-	} else {
-		manifest, _, err = p.PutBlobWithAutopay(wallet, hex.EncodeToString(operationID[:]), value, metadata, opts, *autopay)
+	decodedWalletID, decodedOperationID, _, err := rgb11wallet.DecodeEncryptedSnapshot(value)
+	if err != nil || decodedWalletID != walletID || decodedOperationID != operationID {
+		return nil, ErrRGB11Inconsistent
 	}
-	return manifest, err
+	accountID, err := dkvsAccountID(wallet)
+	if err != nil {
+		return nil, err
+	}
+	blobName := RGB11WalletSnapshotBlobKey(walletID)
+	key, err := dkvsindexer.BlobKey(accountID, blobName)
+	if err != nil {
+		return nil, err
+	}
+	precondition, existing, err := p.dkvsWritePrecondition(key)
+	if err != nil {
+		return nil, err
+	}
+	if opts.Seq == 0 {
+		opts.Seq = 1
+		if existing != nil {
+			opts.Seq = existing.Seq + 1
+		}
+	}
+	var record *swire.DKVSRecord
+	switch {
+	case freeLocal:
+		record, err = BuildDKVSSignedBlobRecordFreeLocal(wallet, blobName, value, nil, opts)
+	case autopay != nil:
+		record, err = BuildDKVSSignedBlobRecord(wallet, blobName, value, nil, opts, *autopay)
+	default:
+		record, err = buildDKVSBlobRecord(wallet, blobName, value, nil, opts)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return p.PutRecordCAS(record, precondition)
 }
 
 func (p *SatsNetDKVSClient) GetRGB11WalletSnapshot(walletPubKey []byte, walletID string,
 	operationID [32]byte, verifyOpts dkvsindexer.RecordVerificationOptions) ([]byte, *swire.DKVSRecord, error) {
 	accountID := dkvsindexer.AccountID(walletPubKey)
-	objectID := hex.EncodeToString(operationID[:])
-	key, err := dkvsindexer.BlobManifestKey(accountID, objectID)
-	if err != nil {
-		return nil, nil, err
+	if accountID == "" {
+		return nil, nil, dkvsindexer.ErrInvalidSignature
 	}
-	verifyOpts.ExpectedKey = key
-	record, err := p.GetVerifiedRecord(key, verifyOpts)
+	record, blob, err := p.GetBlob(accountID, RGB11WalletSnapshotBlobKey(walletID), verifyOpts)
 	if err != nil {
 		return nil, nil, err
 	}
 	if err := verifyRGB11DKVSAccountOwner(record, walletPubKey); err != nil {
 		return nil, nil, err
 	}
-	_, value, err := p.GetBlob(accountID, objectID, dkvsindexer.BlobPolicy{})
-	if err != nil {
-		return nil, nil, err
+	envelopeWalletID, envelopeOperationID, _, err := rgb11wallet.DecodeEncryptedSnapshot(blob.Data)
+	if err != nil || envelopeWalletID != walletID || envelopeOperationID != operationID {
+		return nil, nil, ErrRGB11Inconsistent
 	}
-	return value, record, nil
+	return blob.Data, record, nil
 }
 
 // BuildRGB11RelayRecord builds the signed temporary locator. Consignment
@@ -2539,146 +2692,4 @@ func (p *SatsNetDKVSClient) SubscribeRGB11Transfer(relayKey, ackKey string) ([]*
 		return nil, err
 	}
 	return append(relayRecords, ackRecords...), nil
-}
-
-const (
-	rgb11WalletSnapshotMetadataPrefix = "SAT20-RGB11-WALLET-SNAPSHOT-V1\x00"
-	rgb11SnapshotGCPageSize           = 1000
-)
-
-func rgb11WalletSnapshotMetadata(walletID string) []byte {
-	return []byte(rgb11WalletSnapshotMetadataPrefix + walletID)
-}
-
-// pruneRGB11WalletSnapshots removes superseded immutable snapshot blobs only
-// while the expected wallet head remains active. Tombstones are fee-free and
-// signed by the same wallet.
-func (p *SatsNetDKVSClient) requireRGB11WalletHead(wallet common.Wallet, walletID string,
-	expected *coresync.WalletHead) error {
-
-	pubKey, err := dkvsWalletPubKey(wallet)
-	if err != nil {
-		return err
-	}
-	active, _, err := p.GetRGB11WalletHead(pubKey, walletID, dkvsindexer.RecordVerificationOptions{
-		Now: uint64(time.Now().UnixMilli()),
-	})
-	if expected == nil {
-		if errors.Is(err, ErrDKVSRecordNotFound) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		return coresync.ErrHeadConflict
-	}
-	if err != nil {
-		if errors.Is(err, ErrDKVSRecordNotFound) {
-			return coresync.ErrHeadConflict
-		}
-		return err
-	}
-	if active == nil {
-		return coresync.ErrHeadConflict
-	}
-	if *active != *expected {
-		return coresync.ErrHeadConflict
-	}
-	return nil
-}
-
-func (p *SatsNetDKVSClient) pruneRGB11WalletSnapshots(wallet common.Wallet, walletID string,
-	expected *coresync.WalletHead, keepOperationIDs ...[32]byte) error {
-
-	if p == nil || wallet == nil || walletID == "" {
-		return dkvsindexer.ErrInvalidRecord
-	}
-	if err := p.requireRGB11WalletHead(wallet, walletID, expected); err != nil {
-		return err
-	}
-	pubKey, err := dkvsWalletPubKey(wallet)
-	if err != nil {
-		return err
-	}
-	accountID := dkvsindexer.AccountID(pubKey)
-	if accountID == "" {
-		return dkvsindexer.ErrInvalidSignature
-	}
-	prefix := "/blob/" + accountID
-	records := make([]*swire.DKVSRecord, 0)
-	for start := 0; ; {
-		page, total, err := p.ListRecords(prefix, start, rgb11SnapshotGCPageSize)
-		if err != nil {
-			return err
-		}
-		records = append(records, page...)
-		start += len(page)
-		if len(page) == 0 || start >= total {
-			break
-		}
-	}
-
-	marker := rgb11WalletSnapshotMetadata(walletID)
-	keepObjects := make(map[string]struct{}, len(keepOperationIDs))
-	for _, operationID := range keepOperationIDs {
-		keepObjects[hex.EncodeToString(operationID[:])] = struct{}{}
-	}
-	removeObjects := make(map[string]struct{})
-	for _, record := range records {
-		if record == nil {
-			continue
-		}
-		parsed, err := dkvsindexer.ParseKey(record.Key)
-		if err != nil || parsed.Namespace != "blob" || len(parsed.Segments) != 3 ||
-			parsed.Segments[0] != accountID || parsed.Segments[2] != "manifest" {
-			continue
-		}
-		manifest, err := dkvsindexer.ParseBlobManifestValue(record.Value, dkvsindexer.DefaultBlobPolicy())
-		if err != nil || !bytes.Equal(manifest.Metadata, marker) {
-			continue
-		}
-		if _, keep := keepObjects[parsed.Segments[1]]; keep {
-			continue
-		}
-		removeObjects[parsed.Segments[1]] = struct{}{}
-	}
-	if len(removeObjects) == 0 {
-		return nil
-	}
-	if err := p.requireRGB11WalletHead(wallet, walletID, expected); err != nil {
-		return err
-	}
-
-	remove := make([]*swire.DKVSRecord, 0)
-	for _, record := range records {
-		if record == nil {
-			continue
-		}
-		parsed, err := dkvsindexer.ParseKey(record.Key)
-		if err != nil || parsed.Namespace != "blob" || len(parsed.Segments) < 3 || parsed.Segments[0] != accountID {
-			continue
-		}
-		if _, ok := removeObjects[parsed.Segments[1]]; ok {
-			remove = append(remove, record)
-		}
-	}
-	// Delete chunks first and manifests last. This avoids leaving a live
-	// manifest that advertises already-deleted chunks during partial cleanup.
-	sort.Slice(remove, func(a, b int) bool {
-		parsedA, _ := dkvsindexer.ParseKey(remove[a].Key)
-		parsedB, _ := dkvsindexer.ParseKey(remove[b].Key)
-		manifestA := len(parsedA.Segments) == 3 && parsedA.Segments[2] == "manifest"
-		manifestB := len(parsedB.Segments) == 3 && parsedB.Segments[2] == "manifest"
-		if manifestA != manifestB {
-			return !manifestA
-		}
-		return remove[a].Key < remove[b].Key
-	})
-	for _, record := range remove {
-		_, err := p.TombstoneSigned(wallet, record.Key, dkvsindexer.RecordOptions{Seq: record.Seq + 1})
-		if err != nil && !errors.Is(err, ErrDKVSRecordNotFound) {
-			return err
-		}
-	}
-	return nil
 }

--- a/sdk/wallet/rgb11_snapshot_gc_test.go
+++ b/sdk/wallet/rgb11_snapshot_gc_test.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
@@ -11,9 +10,9 @@ import (
 	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
 )
 
-// Continuous AUTOPAY keeps one active recoverable snapshot generation instead
-// of charging for every historical generation indefinitely.
-func TestRGB11PaidBackupPrunesSupersededSnapshot(t *testing.T) {
+// Continuous retention updates one stable snapshot key and its head in the
+// same batch-CAS transaction.
+func TestRGB11PaidBackupReplacesStableSnapshot(t *testing.T) {
 	priv, err := btcec.NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
@@ -42,32 +41,33 @@ func TestRGB11PaidBackupPrunesSupersededSnapshot(t *testing.T) {
 
 	pubKey := priv.PubKey().SerializeCompressed()
 	if _, _, err := client.GetRGB11WalletSnapshot(pubKey, walletID, head1.OperationID,
-		dkvsindexer.RecordVerificationOptions{Now: uint64(time.Now().UnixMilli())}); !errors.Is(err, ErrDKVSRecordNotFound) {
-		t.Fatalf("superseded snapshot remained active: %v", err)
+		dkvsindexer.RecordVerificationOptions{Now: uint64(time.Now().UnixMilli())}); !errors.Is(err, ErrRGB11Inconsistent) {
+		t.Fatalf("old operation unexpectedly resolved: %v", err)
 	}
 	if _, _, err := client.GetRGB11WalletSnapshot(pubKey, walletID, head2.OperationID,
 		dkvsindexer.RecordVerificationOptions{Now: uint64(time.Now().UnixMilli())}); err != nil {
 		t.Fatalf("latest snapshot missing: %v", err)
 	}
 
+	accountID := dkvsindexer.AccountID(pubKey)
+	wantKey, err := dkvsindexer.BlobKey(accountID, RGB11WalletSnapshotBlobKey(walletID))
+	if err != nil {
+		t.Fatal(err)
+	}
 	remote.mu.Lock()
 	defer remote.mu.Unlock()
-	activeManifests := 0
-	for key, record := range remote.records {
-		if record == nil || !strings.HasSuffix(key, "/manifest") {
-			continue
-		}
-		manifest, err := dkvsindexer.ParseBlobManifestValue(record.Value, dkvsindexer.DefaultBlobPolicy())
-		if err == nil && string(manifest.Metadata) == string(rgb11WalletSnapshotMetadata(walletID)) {
-			activeManifests++
+	blobCount := 0
+	for key := range remote.records {
+		if strings.HasPrefix(key, "/blob/"+accountID+"/") {
+			blobCount++
 		}
 	}
-	if activeManifests != 1 {
-		t.Fatalf("active wallet snapshot manifests=%d", activeManifests)
+	if blobCount != 1 || remote.records[wantKey] == nil {
+		t.Fatalf("blob count=%d stable snapshot=%v", blobCount, remote.records[wantKey] != nil)
 	}
 }
 
-func TestRGB11BackupPrunesOrphansBeforeCapacityIsNeeded(t *testing.T) {
+func TestRGB11BackupUpdatesWithinFixedRecordCapacity(t *testing.T) {
 	priv, err := btcec.NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
@@ -85,19 +85,9 @@ func TestRGB11BackupPrunesOrphansBeforeCapacityIsNeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	orphanID := [32]byte{0x7f}
-	if _, _, err := client.PutBlob(
-		manager.wallet,
-		hex.EncodeToString(orphanID[:]),
-		[]byte("orphan"),
-		rgb11WalletSnapshotMetadata(walletID),
-		dkvsindexer.RecordOptions{Seq: 1, TTL: 60_000},
-	); err != nil {
-		t.Fatal(err)
-	}
-
 	remote.mu.Lock()
-	remote.maxRecords = len(remote.records)
+	initialRecords := len(remote.records)
+	remote.maxRecords = initialRecords
 	remote.mu.Unlock()
 
 	createRGB11MultiDeviceInvoice(t, manager, "capacity-two")
@@ -105,16 +95,11 @@ func TestRGB11BackupPrunesOrphansBeforeCapacityIsNeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if head2.Seq != head1.Seq+1 {
-		t.Fatalf("head sequence=%d want=%d", head2.Seq, head1.Seq+1)
-	}
-	if _, _, err := client.GetRGB11WalletSnapshot(
-		priv.PubKey().SerializeCompressed(),
-		walletID,
-		orphanID,
-		dkvsindexer.RecordVerificationOptions{Now: uint64(time.Now().UnixMilli())},
-	); !errors.Is(err, ErrDKVSRecordNotFound) {
-		t.Fatalf("orphan snapshot remained active: %v", err)
+	remote.mu.Lock()
+	finalRecords := len(remote.records)
+	remote.mu.Unlock()
+	if head2.Seq != head1.Seq+1 || finalRecords != initialRecords {
+		t.Fatalf("head sequence=%d records=%d want records=%d", head2.Seq, finalRecords, initialRecords)
 	}
 }
 

--- a/sdk/wallet/rgb11_sync_test.go
+++ b/sdk/wallet/rgb11_sync_test.go
@@ -16,6 +16,7 @@ import (
 	sdkcommon "github.com/sat20-labs/sat20wallet/sdk/common"
 	rgb11wallet "github.com/sat20-labs/sat20wallet/sdk/wallet/rgb11"
 	"github.com/sat20-labs/satoshinet/btcec"
+	"github.com/sat20-labs/satoshinet/chaincfg/chainhash"
 	dkvsindexer "github.com/sat20-labs/satoshinet/indexer/indexer/dkvs"
 	swire "github.com/sat20-labs/satoshinet/wire"
 	"os"
@@ -286,17 +287,15 @@ func TestRGB11RelayAndAckRoundTripThroughDKVS(t *testing.T) {
 
 // rgb11MemoryDKVSHTTP models the one property the multi-device protocol relies
 // on from DKVS: a key may advance only to a strictly newer wallet-signed
-// sequence. Immutable snapshot blobs use unique keys and remain independently
-// retrievable.
+// sequence. Related key updates are committed atomically through batch-CAS.
 type rgb11MemoryDKVSHTTP struct {
-	mu                 sync.Mutex
-	records            map[string]*swire.DKVSRecord
-	postGate           <-chan struct{}
-	autopayState       *dkvsindexer.AutopayContractState
-	autopayError       error
-	freeLocal          dkvsindexer.FreeLocalCachePolicy
-	validateBlobChunks bool
-	maxRecords         int
+	mu           sync.Mutex
+	records      map[string]*swire.DKVSRecord
+	postGate     <-chan struct{}
+	autopayState *dkvsindexer.AutopayContractState
+	autopayError error
+	freeLocal    dkvsindexer.FreeLocalCachePolicy
+	maxRecords   int
 }
 
 func newRGB11MemoryDKVSHTTP() *rgb11MemoryDKVSHTTP {
@@ -317,6 +316,61 @@ func (h *rgb11MemoryDKVSHTTP) SendPostRequest(url *URL, body []byte) ([]byte, er
 	if h.postGate != nil {
 		<-h.postGate
 	}
+	switch {
+	case strings.HasSuffix(url.Path, "/v3/dkvs/records/batch-cas"):
+		var req DKVSBatchCASRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		return h.applyBatchCAS(req.Mutations)
+	case strings.HasSuffix(url.Path, "/v3/dkvs/records/cas"):
+		var req DKVSCASMutationRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		result, err := h.applyBatchCAS([]DKVSCASMutationRequest{req})
+		if err != nil {
+			return nil, err
+		}
+		var batch struct {
+			Code int                 `json:"code"`
+			Msg  string              `json:"msg"`
+			Data *DKVSBatchCASResult `json:"data"`
+		}
+		if err := json.Unmarshal(result, &batch); err != nil {
+			return nil, err
+		}
+		if batch.Code != 0 || batch.Data == nil || len(batch.Data.Records) != 1 {
+			return result, nil
+		}
+		hash := dkvsindexer.RecordHash(batch.Data.Records[0])
+		return json.Marshal(map[string]interface{}{
+			"code": 0, "msg": "ok", "data": batch.Data.Records[0], "hash": hash.String(),
+		})
+	case strings.HasSuffix(url.Path, "/v3/dkvs/sync/directory"):
+		var req DKVSDirectorySyncRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		return h.syncDirectory(req)
+	case strings.HasSuffix(url.Path, "/v3/dkvs/watch/directory"):
+		var req DKVSDirectoryWatchRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		sync, err := h.syncDirectory(DKVSDirectorySyncRequest{Prefix: req.Prefix})
+		if err != nil {
+			return nil, err
+		}
+		var response dkvsSyncResp
+		if err := json.Unmarshal(sync, &response); err != nil || response.Data == nil {
+			return nil, err
+		}
+		return rgb11DKVSResponse(0, "ok", &DKVSWatchResult{
+			Changed: response.Data.Root != req.Root, Root: response.Data.Root,
+		}, 0)
+	}
+
 	recordPath := strings.HasSuffix(url.Path, "/v3/dkvs/records")
 	tombstonePath := strings.HasSuffix(url.Path, "/v3/dkvs/tombstone")
 	if !recordPath && !tombstonePath {
@@ -331,29 +385,11 @@ func (h *rgb11MemoryDKVSHTTP) SendPostRequest(url *URL, body []byte) ([]byte, er
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.validateBlobChunks {
-		parsed, err := dkvsindexer.ParseKey(record.Key)
-		if err != nil {
-			return rgb11DKVSResponse(1, err.Error(), nil, 0)
-		}
-		if parsed.Namespace == "blob" && len(parsed.Segments) == 4 && parsed.Segments[2] == "chunk" {
-			manifestKey := "/blob/" + parsed.Segments[0] + "/" + parsed.Segments[1] + "/manifest"
-			manifest := h.records[manifestKey]
-			if manifest == nil || record.Seq != manifest.Seq ||
-				record.IssueTime != manifest.IssueTime || record.TTL != manifest.TTL ||
-				record.ExpiryHeight != manifest.ExpiryHeight {
-				return rgb11DKVSResponse(1, dkvsindexer.ErrBlobChunkInvalid.Error(), nil, 0)
-			}
-		}
-	}
 	if h.maxRecords > 0 && !tombstonePath && h.records[record.Key] == nil &&
 		len(h.records) >= h.maxRecords {
 		return rgb11DKVSResponse(1, dkvsindexer.ErrFeeCapacityExceeded.Error(), nil, 0)
 	}
 	if current := h.records[record.Key]; current != nil && record.Seq <= current.Seq {
-		// The production endpoint returns the submitted record even when the
-		// selector keeps the existing active record. The client must re-read the
-		// key before treating its candidate as the latest wallet head.
 		return rgb11DKVSResponse(0, "ok", &record, 0)
 	}
 	if tombstonePath {
@@ -364,11 +400,103 @@ func (h *rgb11MemoryDKVSHTTP) SendPostRequest(url *URL, body []byte) ([]byte, er
 	return rgb11DKVSResponse(0, "ok", &record, 0)
 }
 
+func (h *rgb11MemoryDKVSHTTP) applyBatchCAS(mutations []DKVSCASMutationRequest) ([]byte, error) {
+	if len(mutations) == 0 {
+		return rgb11DKVSResponse(1, dkvsindexer.ErrInvalidRecord.Error(), nil, 0)
+	}
+	for _, mutation := range mutations {
+		if mutation.Record == nil {
+			return rgb11DKVSResponse(1, dkvsindexer.ErrInvalidRecord.Error(), nil, 0)
+		}
+		if err := dkvsindexer.VerifySignature(mutation.Record); err != nil {
+			return rgb11DKVSResponse(1, err.Error(), nil, 0)
+		}
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	already := 0
+	for _, mutation := range mutations {
+		current := h.records[mutation.Record.Key]
+		if current != nil && dkvsindexer.RecordHash(current) == dkvsindexer.RecordHash(mutation.Record) {
+			already++
+		}
+	}
+	if already != 0 && already != len(mutations) {
+		return rgb11DKVSResponse(1, dkvsindexer.ErrWriteConflict.Error(), nil, 0)
+	}
+	if already == 0 {
+		for _, mutation := range mutations {
+			current := h.records[mutation.Record.Key]
+			if mutation.ExpectAbsent {
+				if current != nil {
+					return rgb11DKVSResponse(1, dkvsindexer.ErrWriteConflict.Error(), nil, 0)
+				}
+				continue
+			}
+			want, err := chainhash.NewHashFromStr(mutation.ExpectedHash)
+			if err != nil || current == nil || dkvsindexer.RecordHash(current) != *want {
+				return rgb11DKVSResponse(1, dkvsindexer.ErrWriteConflict.Error(), nil, 0)
+			}
+		}
+		projected := len(h.records)
+		for _, mutation := range mutations {
+			_, existed := h.records[mutation.Record.Key]
+			if dkvsindexer.IsTombstone(mutation.Record.Flags) {
+				if existed {
+					projected--
+				}
+			} else if !existed {
+				projected++
+			}
+		}
+		if h.maxRecords > 0 && projected > h.maxRecords {
+			return rgb11DKVSResponse(1, dkvsindexer.ErrFeeCapacityExceeded.Error(), nil, 0)
+		}
+		for _, mutation := range mutations {
+			if dkvsindexer.IsTombstone(mutation.Record.Flags) {
+				delete(h.records, mutation.Record.Key)
+			} else {
+				h.records[mutation.Record.Key] = cloneRGB11DKVSRecord(mutation.Record)
+			}
+		}
+	}
+	records := make([]*swire.DKVSRecord, 0, len(mutations))
+	hashes := make([]string, 0, len(mutations))
+	for _, mutation := range mutations {
+		records = append(records, cloneRGB11DKVSRecord(mutation.Record))
+		hash := dkvsindexer.RecordHash(mutation.Record)
+		hashes = append(hashes, hash.String())
+	}
+	return rgb11DKVSResponse(0, "ok", &DKVSBatchCASResult{
+		Applied: len(mutations) - already, Records: records, Hashes: hashes,
+	}, 0)
+}
+
+func (h *rgb11MemoryDKVSHTTP) syncDirectory(req DKVSDirectorySyncRequest) ([]byte, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	prefix := strings.TrimSuffix(req.Prefix, "/")
+	records := make([]*swire.DKVSRecord, 0)
+	for key, record := range h.records {
+		if key == prefix || strings.HasPrefix(key, prefix+"/") {
+			records = append(records, cloneRGB11DKVSRecord(record))
+		}
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].Key < records[j].Key })
+	root, err := dkvsindexer.DirectoryRootFromRecords(records, 0)
+	if err != nil {
+		return nil, err
+	}
+	return rgb11DKVSResponse(0, "ok", &DKVSSyncPage{
+		Records: records, Done: true, Root: root.String(),
+	}, 0)
+}
+
 func (h *rgb11MemoryDKVSHTTP) SendGetRequest(url *URL) ([]byte, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if strings.HasSuffix(url.Path, "/v3/dkvs/config") {
-		return rgb11DKVSResponse(0, "ok", h.freeLocal, 0)
+		return rgb11DKVSResponse(0, "ok", dkvsindexer.ClientConfig{FreeLocal: h.freeLocal, Blob: dkvsindexer.DefaultBlobPolicy(), MaxBatchMutations: dkvsindexer.MaxBatchCASMutations, MaxBatchBytes: dkvsindexer.MaxBatchCASTotalSize}, 0)
 	}
 	if strings.Contains(url.Path, "/v3/contracts/") && strings.HasSuffix(url.Path, "/state") {
 		if h.autopayError != nil {
@@ -564,9 +692,9 @@ func TestRGB11ManualFirstBackupEnablesAutomaticBackupAndActivationRestore(t *tes
 			continue
 		}
 		proof, err := dkvsindexer.ParseFeeProof(record.FeeProof)
-		if err != nil || proof.Mode != dkvsindexer.FeeModeAutopay || proof.PoolContract == "" {
+		if err != nil || proof.Mode != dkvsindexer.FeeModeFreeLocal {
 			remote.mu.Unlock()
-			t.Fatalf("RGB11 backup record %s has no valid AUTOPAY proof: proof=%+v err=%v", key, proof, err)
+			t.Fatalf("RGB11 backup record %s has no valid FREE_LOCAL proof: proof=%+v err=%v", key, proof, err)
 		}
 		if err := dkvsindexer.VerifySignature(record); err != nil {
 			remote.mu.Unlock()


### PR DESCRIPTION
## Summary

This PR moves the Wallet SDK and RGB11 persistence flow to the application-facing DKVS RPC model introduced by `sat20-labs/satoshinet#13`.

- adds strict RPC directory synchronization and long-poll watch support
- adds single-key CAS and general atomic batch-CAS clients
- replaces manifest/chunk blob APIs with one signed `/blob/<account_id>/<blob_key>` record
- supports AUTOPAY and node-policy-limited FREE_LOCAL blobs up to 1 MiB
- validates page roots, cursor progress, directory membership, signatures, account identity and duplicate-key conflicts
- verifies server echo records and committed hashes
- updates RGB11 snapshot blob and head atomically in one batch-CAS
- updates large RGB11 payload blob and mailbox locator atomically in one batch-CAS
- removes obsolete chunk-oriented SDK code and tests
- preserves existing production compatibility code; legacy `copylocks` warnings are intentionally not modified
- updates CI to test against the matching SatoshiNet feature branch and to verify the freshly built WASM artifact

## Validation

GitHub Actions completed successfully:

- Account management run #98: success
- RGB11 address transfer scheme A run #282: success

The workflows cover:

```text
go test ./account/... -count=1
go vet -copylocks=false ./wallet/...
go test ./wallet -run '^$' -count=1
go test ./wallet/... -count=1
go test ./e2e -run '^$' -count=1
GOOS=js GOARCH=wasm go build ./wasm
PWA type-check and RGB11 integration smoke verification
```

The final diff contains Wallet SDK, RGB11 persistence, tests and necessary CI adjustments. Temporary payload, source-snapshot and publishing helper files are absent.

## Dependency and merge order

1. Review and merge `sat20-labs/satoshinet#13`.
2. Review this PR against the merged SatoshiNet API and then merge it.